### PR TITLE
Support for bot's inline mode (#33)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 }
 
 plugins {
-    id "org.jetbrains.kotlin.jvm" version "1.2.50"
+    id "org.jetbrains.kotlin.jvm" version "1.3.50"
 }
 
 allprojects {

--- a/samples/dispatcher/src/main/kotlin/me/ivmg/dispatcher/Main.kt
+++ b/samples/dispatcher/src/main/kotlin/me/ivmg/dispatcher/Main.kt
@@ -8,6 +8,7 @@ import me.ivmg.telegram.dispatcher.channel
 import me.ivmg.telegram.dispatcher.command
 import me.ivmg.telegram.dispatcher.contact
 import me.ivmg.telegram.dispatcher.handlers.CallbackQueryHandler
+import me.ivmg.telegram.dispatcher.inlineQuery
 import me.ivmg.telegram.dispatcher.location
 import me.ivmg.telegram.dispatcher.message
 import me.ivmg.telegram.dispatcher.telegramError
@@ -17,6 +18,8 @@ import me.ivmg.telegram.entities.InlineKeyboardMarkup
 import me.ivmg.telegram.entities.KeyboardButton
 import me.ivmg.telegram.entities.KeyboardReplyMarkup
 import me.ivmg.telegram.entities.ReplyKeyboardRemove
+import me.ivmg.telegram.entities.inlinequeryresults.InlineQueryResult
+import me.ivmg.telegram.entities.inlinequeryresults.InputMessageContent
 import me.ivmg.telegram.extensions.filters.Filter
 import me.ivmg.telegram.network.fold
 import okhttp3.logging.HttpLoggingInterceptor
@@ -118,6 +121,22 @@ fun main(args: Array<String>) {
 
             channel { bot, update ->
                 // Handle channel update
+            }
+
+            inlineQuery { bot, inlineQuery ->
+                val queryText = inlineQuery.query
+
+                if (queryText.isBlank() or queryText.isEmpty()) return@inlineQuery
+
+                val inlineResults = (0 until 5).map {
+                    InlineQueryResult.Article(
+                        id = it.toString(),
+                        title = "$it. $queryText",
+                        inputMessageContent = InputMessageContent.Text("$it. $queryText"),
+                        description = "Add $it. before you word"
+                    )
+                }
+                bot.answerInlineQuery(inlineQuery.id, inlineResults)
             }
 
             telegramError { _, telegramError ->

--- a/telegram/src/main/kotlin/me/ivmg/telegram/Bot.kt
+++ b/telegram/src/main/kotlin/me/ivmg/telegram/Bot.kt
@@ -9,6 +9,7 @@ import me.ivmg.telegram.entities.InlineKeyboardMarkup
 import me.ivmg.telegram.entities.ParseMode
 import me.ivmg.telegram.entities.ReplyMarkup
 import me.ivmg.telegram.entities.Update
+import me.ivmg.telegram.entities.inlinequeryresults.InlineQueryResult
 import me.ivmg.telegram.entities.inputmedia.InputMedia
 import me.ivmg.telegram.entities.payments.PaymentInvoiceInfo
 import me.ivmg.telegram.entities.payments.ShippingOption
@@ -882,5 +883,41 @@ class Bot private constructor(
         preCheckoutQueryId,
         ok,
         errorMessage
+    ).call()
+
+    fun answerInlineQuery(
+        inlineQueryId: String,
+        vararg inlineQueryResults: InlineQueryResult,
+        cacheTime: Int? = null,
+        isPersonal: Boolean = false,
+        nextOffset: String? = null,
+        switchPmText: String? = null,
+        switchPmParameter: String? = null
+    ) = answerInlineQuery(
+        inlineQueryId,
+        inlineQueryResults.toList(),
+        cacheTime,
+        isPersonal,
+        nextOffset,
+        switchPmText,
+        switchPmParameter
+    )
+
+    fun answerInlineQuery(
+        inlineQueryId: String,
+        inlineQueryResults: List<InlineQueryResult>,
+        cacheTime: Int? = null,
+        isPersonal: Boolean = false,
+        nextOffset: String? = null,
+        switchPmText: String? = null,
+        switchPmParameter: String? = null
+    ) = apiClient.answerInlineQuery(
+        inlineQueryId,
+        inlineQueryResults,
+        cacheTime,
+        isPersonal,
+        nextOffset,
+        switchPmText,
+        switchPmParameter
     ).call()
 }

--- a/telegram/src/main/kotlin/me/ivmg/telegram/Callbacks.kt
+++ b/telegram/src/main/kotlin/me/ivmg/telegram/Callbacks.kt
@@ -1,6 +1,7 @@
 package me.ivmg.telegram
 
 import me.ivmg.telegram.entities.Contact
+import me.ivmg.telegram.entities.InlineQuery
 import me.ivmg.telegram.entities.Location
 import me.ivmg.telegram.entities.Update
 import me.ivmg.telegram.errors.TelegramError
@@ -14,3 +15,5 @@ typealias CommandHandleUpdate = (Bot, Update, List<String>) -> Unit
 typealias ContactHandleUpdate = (Bot, Update, Contact) -> Unit
 
 typealias LocationHandleUpdate = (Bot, Update, Location) -> Unit
+
+typealias HandleInlineQuery = (Bot, InlineQuery) -> Unit

--- a/telegram/src/main/kotlin/me/ivmg/telegram/dispatcher/Dispatcher.kt
+++ b/telegram/src/main/kotlin/me/ivmg/telegram/dispatcher/Dispatcher.kt
@@ -6,6 +6,7 @@ import me.ivmg.telegram.Bot
 import me.ivmg.telegram.CommandHandleUpdate
 import me.ivmg.telegram.ContactHandleUpdate
 import me.ivmg.telegram.HandleError
+import me.ivmg.telegram.HandleInlineQuery
 import me.ivmg.telegram.HandleUpdate
 import me.ivmg.telegram.LocationHandleUpdate
 import me.ivmg.telegram.dispatcher.handlers.CallbackQueryHandler
@@ -14,6 +15,7 @@ import me.ivmg.telegram.dispatcher.handlers.CheckoutHandler
 import me.ivmg.telegram.dispatcher.handlers.CommandHandler
 import me.ivmg.telegram.dispatcher.handlers.ContactHandler
 import me.ivmg.telegram.dispatcher.handlers.Handler
+import me.ivmg.telegram.dispatcher.handlers.InlineQueryHandler
 import me.ivmg.telegram.dispatcher.handlers.LocationHandler
 import me.ivmg.telegram.dispatcher.handlers.MessageHandler
 import me.ivmg.telegram.dispatcher.handlers.TextHandler
@@ -64,6 +66,10 @@ fun Dispatcher.preCheckoutQuery(body: HandleUpdate) {
 
 fun Dispatcher.channel(body: HandleUpdate) {
     addHandler(ChannelHandler(body))
+}
+
+fun Dispatcher.inlineQuery(body: HandleInlineQuery) {
+    addHandler(InlineQueryHandler(body))
 }
 
 class Dispatcher {

--- a/telegram/src/main/kotlin/me/ivmg/telegram/dispatcher/handlers/InlineQueryHandler.kt
+++ b/telegram/src/main/kotlin/me/ivmg/telegram/dispatcher/handlers/InlineQueryHandler.kt
@@ -1,0 +1,26 @@
+package me.ivmg.telegram.dispatcher.handlers
+
+import me.ivmg.telegram.Bot
+import me.ivmg.telegram.HandleInlineQuery
+import me.ivmg.telegram.HandleUpdate
+import me.ivmg.telegram.entities.Update
+
+class InlineQueryHandler(
+    handleInlineQuery: HandleInlineQuery
+) : Handler(InlineQueryHandlerProxy(handleInlineQuery)) {
+    override val groupIdentifier: String
+        get() = "InlineQueryHandler"
+
+    override fun checkUpdate(update: Update): Boolean = update.inlineQuery != null
+}
+
+private class InlineQueryHandlerProxy(
+    private val handleInlineQuery: HandleInlineQuery
+) : HandleUpdate {
+
+    override fun invoke(bot: Bot, update: Update) {
+        val inlineQuery = update.inlineQuery
+        checkNotNull(inlineQuery)
+        handleInlineQuery(bot, inlineQuery)
+    }
+}

--- a/telegram/src/main/kotlin/me/ivmg/telegram/entities/inlinequeryresults/InlineQueryResult.kt
+++ b/telegram/src/main/kotlin/me/ivmg/telegram/entities/inlinequeryresults/InlineQueryResult.kt
@@ -1,0 +1,261 @@
+package me.ivmg.telegram.entities.inlinequeryresults
+
+import com.google.gson.annotations.SerializedName
+import me.ivmg.telegram.entities.InlineKeyboardMarkup
+import me.ivmg.telegram.entities.ParseMode
+
+enum class MimeType(val rawName: String) {
+    TEXT_HTML("text/html"),
+    VIDEO_MP4("video/mp4"),
+    APPLICATION_PDF("application/pdf"),
+    APPLICATION_ZIP("application/zip")
+}
+
+fun String.toMimeType(): MimeType? =
+    MimeType.values().firstOrNull { type -> this == type.rawName }
+
+private object QueryResultTypes {
+    const val ARTICLE = "article"
+    const val PHOTO = "photo"
+    const val VIDEO = "video"
+    const val VOICE = "voice"
+    const val STICKER = "sticker"
+    const val MPEG4_GIF = "mpeg4_gif"
+    const val GIF = "gif"
+    const val AUDIO = "audio"
+    const val DOCUMENT = "document"
+    const val LOCATION = "location"
+    const val VENUE = "venue"
+    const val CONTACT = "contact"
+    const val GAME = "game"
+}
+
+sealed class InlineQueryResult(
+    val type: String
+) {
+    abstract val id: String
+    abstract val replyMarkup: InlineKeyboardMarkup?
+
+    data class Article(
+        override val id: String,
+        val title: String,
+        @SerializedName("input_message_content") val inputMessageContent: InputMessageContent,
+        @SerializedName("reply_markup") override val replyMarkup: InlineKeyboardMarkup? = null,
+        val url: String? = null,
+        @SerializedName("hide_url") val hideUrl: Boolean? = null,
+        val description: String? = null,
+        @SerializedName("thumb_url") val thumbUrl: String? = null,
+        @SerializedName("thumb_width") val thumbWidth: Int? = null,
+        @SerializedName("thumb_height") val thumbHeight: Int? = null
+    ) : InlineQueryResult(QueryResultTypes.ARTICLE)
+
+    data class Photo(
+        override val id: String,
+        @SerializedName("photo_url") val photoUrl: String,
+        @SerializedName("thumb_url") val thumbUrl: String,
+        @SerializedName("photo_width") val photoWidth: Int? = null,
+        @SerializedName("photo_height") val photoHeight: Int? = null,
+        val title: String? = null,
+        val description: String? = null,
+        val caption: String? = null,
+        @SerializedName("parse_mode") val parseMode: ParseMode? = null,
+        @SerializedName("reply_markup") override val replyMarkup: InlineKeyboardMarkup? = null,
+        @SerializedName("input_message_content") val inputMessageContent: InputMessageContent? = null
+    ) : InlineQueryResult(QueryResultTypes.PHOTO)
+
+    data class Gif(
+        override val id: String,
+        @SerializedName("gif_url") val gifUrl: String,
+        @SerializedName("gif_width") val gifWidth: Int? = null,
+        @SerializedName("gif_height") val gifHeight: Int? = null,
+        @SerializedName("gif_duration") val gifDuration: Int? = null,
+        @SerializedName("thumb_url") val thumbUrl: String,
+        val title: String? = null,
+        val caption: String? = null,
+        @SerializedName("parse_mode") val parseMode: ParseMode? = null,
+        @SerializedName("reply_markup") override val replyMarkup: InlineKeyboardMarkup? = null,
+        @SerializedName("input_message_content") val inputMessageContent: InputMessageContent? = null
+    ) : InlineQueryResult(QueryResultTypes.GIF)
+
+    data class Mpeg4Gif(
+        override val id: String,
+        @SerializedName("mpeg4_url") val mpeg4Url: String,
+        @SerializedName("mpeg4_width") val mpeg4Width: Int? = null,
+        @SerializedName("mpeg4_height") val mpeg4Height: Int? = null,
+        @SerializedName("mpeg4_duration") val mpeg4Duration: Int? = null,
+        @SerializedName("thumb_url") val thumbUrl: String,
+        val title: String? = null,
+        val caption: String? = null,
+        @SerializedName("parse_mode") val parseMode: ParseMode? = null,
+        @SerializedName("reply_markup") override val replyMarkup: InlineKeyboardMarkup? = null,
+        @SerializedName("input_message_content") val inputMessageContent: InputMessageContent? = null
+    ) : InlineQueryResult(QueryResultTypes.MPEG4_GIF)
+
+    data class Video(
+        override val id: String,
+        @SerializedName("video_url") val videoUrl: String,
+        @SerializedName("mime_type") val mimeType: MimeType,
+        @SerializedName("thumb_url") val thumbUrl: String,
+        val title: String,
+        val caption: String? = null,
+        @SerializedName("parse_mode") val parseMode: ParseMode? = null,
+        @SerializedName("video_width") val videoWidth: Int? = null,
+        @SerializedName("video_height") val videoHeight: Int? = null,
+        @SerializedName("video_duration") val videoDuration: Int? = null,
+        val description: String? = null,
+        @SerializedName("reply_markup") override val replyMarkup: InlineKeyboardMarkup? = null,
+        @SerializedName("input_message_content") val inputMessageContent: InputMessageContent? = null
+    ) : InlineQueryResult(QueryResultTypes.VIDEO)
+
+    data class Audio(
+        override val id: String,
+        @SerializedName("audio_url") val audioUrl: String,
+        val title: String,
+        val caption: String? = null,
+        @SerializedName("parse_mode") val parseMode: ParseMode? = null,
+        val performer: String? = null,
+        @SerializedName("audio_duration") val audioDuration: Int? = null,
+        @SerializedName("reply_markup") override val replyMarkup: InlineKeyboardMarkup? = null,
+        @SerializedName("input_message_content") val inputMessageContent: InputMessageContent? = null
+    ) : InlineQueryResult(QueryResultTypes.AUDIO)
+
+    data class Voice(
+        override val id: String,
+        @SerializedName("voice_url") val voiceUrl: String,
+        val title: String,
+        val caption: String? = null,
+        @SerializedName("parse_mode") val parseMode: ParseMode? = null,
+        @SerializedName("voice_duration") val voiceDuration: Int? = null,
+        @SerializedName("reply_markup") override val replyMarkup: InlineKeyboardMarkup? = null,
+        @SerializedName("input_message_content") val inputMessageContent: InputMessageContent? = null
+    ) : InlineQueryResult(QueryResultTypes.VOICE)
+
+    data class Document(
+        override val id: String,
+        val title: String,
+        val caption: String? = null,
+        @SerializedName("parse_mode") val parseMode: ParseMode? = null,
+        @SerializedName("document_url") val documentUrl: String,
+        @SerializedName("mime_type") val mimeType: MimeType,
+        val description: String? = null,
+        @SerializedName("reply_markup") override val replyMarkup: InlineKeyboardMarkup? = null,
+        @SerializedName("input_message_content") val inputMessageContent: InputMessageContent? = null,
+        @SerializedName("thumb_url") val thumbUrl: String? = null,
+        @SerializedName("thumb_width") val thumbWidth: Int? = null,
+        @SerializedName("thumb_height") val thumbHeight: Int? = null
+    ) : InlineQueryResult(QueryResultTypes.DOCUMENT)
+
+    data class Location(
+        override val id: String,
+        val latitude: Float,
+        val longitude: Float,
+        val title: String,
+        @SerializedName("live_period") val livePeriod: Int? = null,
+        @SerializedName("reply_markup") override val replyMarkup: InlineKeyboardMarkup? = null,
+        @SerializedName("input_message_content") val inputMessageContent: InputMessageContent? = null,
+        @SerializedName("thumb_url") val thumbUrl: String? = null,
+        @SerializedName("thumb_width") val thumbWidth: Int? = null,
+        @SerializedName("thumb_height") val thumbHeight: Int? = null
+    ) : InlineQueryResult(QueryResultTypes.LOCATION)
+
+    data class Venue(
+        override val id: String,
+        val latitude: Float,
+        val longitude: Float,
+        val title: String,
+        val address: String,
+        @SerializedName("foursquare_id") val foursquareId: String? = null,
+        @SerializedName("foursquare_type") val foursquareType: String? = null,
+        @SerializedName("reply_markup") override val replyMarkup: InlineKeyboardMarkup? = null,
+        @SerializedName("input_message_content") val inputMessageContent: InputMessageContent? = null,
+        @SerializedName("thumb_url") val thumbUrl: String? = null,
+        @SerializedName("thumb_width") val thumbWidth: Int? = null,
+        @SerializedName("thumb_height") val thumbHeight: Int? = null
+    ) : InlineQueryResult(QueryResultTypes.VENUE)
+
+    data class Contact(
+        override val id: String,
+        @SerializedName("phone_number") val phoneNumber: String,
+        @SerializedName("first_name") val firstName: String,
+        @SerializedName("last_name") val lastName: String? = null,
+        val vcard: String? = null,
+        @SerializedName("reply_markup") override val replyMarkup: InlineKeyboardMarkup? = null,
+        @SerializedName("input_message_content") val inputMessageContent: InputMessageContent? = null,
+        @SerializedName("thumb_url") val thumbUrl: String? = null,
+        @SerializedName("thumb_width") val thumbWidth: Int? = null,
+        @SerializedName("thumb_height") val thumbHeight: Int? = null
+    ) : InlineQueryResult(QueryResultTypes.CONTACT)
+
+    data class Game(
+        override val id: String,
+        @SerializedName("game_short_name") val gameShortName: String,
+        @SerializedName("reply_markup") override val replyMarkup: InlineKeyboardMarkup? = null
+    ) : InlineQueryResult(QueryResultTypes.GAME)
+
+    data class CachedAudio(
+        override val id: String,
+        @SerializedName("audio_file_id") val audioFileId: String,
+        val caption: String? = null,
+        @SerializedName("parse_mode") val parseMode: ParseMode? = null,
+        @SerializedName("reply_markup") override val replyMarkup: InlineKeyboardMarkup? = null,
+        @SerializedName("input_message_content") val inputMessageContent: InputMessageContent? = null
+    ) : InlineQueryResult(QueryResultTypes.AUDIO)
+
+    data class CachedDocument(
+        override val id: String,
+        val title: String,
+        @SerializedName("document_file_id") val documentFileId: String,
+        val description: String? = null,
+        val caption: String? = null,
+        @SerializedName("parse_mode") val parseMode: ParseMode? = null,
+        @SerializedName("reply_markup") override val replyMarkup: InlineKeyboardMarkup? = null,
+        @SerializedName("input_message_content") val inputMessageContent: InputMessageContent? = null
+    ) : InlineQueryResult(QueryResultTypes.DOCUMENT)
+
+    data class CachedGif(
+        override val id: String,
+        @SerializedName("gif_file_id") val gifFileId: String,
+        val title: String? = null,
+        val caption: String? = null,
+        @SerializedName("parse_mode") val parseMode: ParseMode? = null,
+        @SerializedName("reply_markup") override val replyMarkup: InlineKeyboardMarkup? = null,
+        @SerializedName("input_message_content") val inputMessageContent: InputMessageContent? = null
+    ) : InlineQueryResult(QueryResultTypes.GIF)
+
+    data class CachedMpeg4Gif(
+        override val id: String,
+        @SerializedName("mpeg4_file_id") val mpeg4FileId: String,
+        val title: String? = null,
+        val caption: String? = null,
+        @SerializedName("parse_mode") val parseMode: ParseMode? = null,
+        @SerializedName("reply_markup") override val replyMarkup: InlineKeyboardMarkup? = null,
+        @SerializedName("input_message_content") val inputMessageContent: InputMessageContent? = null
+    ) : InlineQueryResult(QueryResultTypes.MPEG4_GIF)
+
+    data class CachedSticker(
+        override val id: String,
+        @SerializedName("sticket_file_id") val stickerFileId: String,
+        @SerializedName("reply_markup") override val replyMarkup: InlineKeyboardMarkup? = null,
+        @SerializedName("input_message_content") val inputMessageContent: InputMessageContent? = null
+    ) : InlineQueryResult(QueryResultTypes.STICKER)
+
+    data class CachedVideo(
+        override val id: String,
+        @SerializedName("video_file_id") val videoFileId: String,
+        val description: String? = null,
+        val caption: String? = null,
+        @SerializedName("parse_mode") val parseMode: ParseMode? = null,
+        @SerializedName("reply_markup") override val replyMarkup: InlineKeyboardMarkup? = null,
+        @SerializedName("input_message_content") val inputMessageContent: InputMessageContent? = null
+    ) : InlineQueryResult(QueryResultTypes.VIDEO)
+
+    data class CachedVoice(
+        override val id: String,
+        @SerializedName("voice_file_id") val voiceFileId: String,
+        val title: String,
+        val caption: String? = null,
+        @SerializedName("parse_mode") val parseModel: ParseMode? = null,
+        @SerializedName("reply_markup") override val replyMarkup: InlineKeyboardMarkup? = null,
+        @SerializedName("input_message_content") val inputMessageContent: InputMessageContent? = null
+    ) : InlineQueryResult(QueryResultTypes.VOICE)
+}

--- a/telegram/src/main/kotlin/me/ivmg/telegram/entities/inlinequeryresults/InputMessageContent.kt
+++ b/telegram/src/main/kotlin/me/ivmg/telegram/entities/inlinequeryresults/InputMessageContent.kt
@@ -1,0 +1,34 @@
+package me.ivmg.telegram.entities.inlinequeryresults
+
+import com.google.gson.annotations.SerializedName
+import me.ivmg.telegram.entities.ParseMode
+
+sealed class InputMessageContent {
+    data class Text(
+        @SerializedName("message_text") val messageText: String,
+        @SerializedName("parse_mode") val parseMode: ParseMode? = null,
+        @SerializedName("disable_web_page_preview") val disableWebPagePreview: Boolean? = null
+    ) : InputMessageContent()
+
+    data class Location(
+        val latitude: Float,
+        val longitude: Float,
+        @SerializedName("live_period") val livePeriod: Int? = null
+    ) : InputMessageContent()
+
+    data class Venue(
+        val latitude: Float,
+        val longitude: Float,
+        val title: String,
+        val address: String,
+        @SerializedName("foursquare_id") val foursquareId: String? = null,
+        @SerializedName("foursquare_type") val foursqeareType: String? = null
+    ) : InputMessageContent()
+
+    data class Contact(
+        @SerializedName("phone_number") val phoneNumber: String,
+        @SerializedName("first_name") val firstName: String,
+        @SerializedName("last_name") val lastName: String? = null,
+        val vcard: String? = null
+    )
+}

--- a/telegram/src/main/kotlin/me/ivmg/telegram/network/ApiService.kt
+++ b/telegram/src/main/kotlin/me/ivmg/telegram/network/ApiService.kt
@@ -691,6 +691,18 @@ interface ApiService {
         @Field("ok") ok: Boolean,
         @Field("error_message") errorMessage: String? = null
     ): Call<Response<Boolean>>
+
+    @FormUrlEncoded
+    @POST("answerInlineQuery")
+    fun answerInlineQuery(
+        @Field("inline_query_id") inlineQueryId: String,
+        @Field("results") inlineQueryResults: String,
+        @Field("cache_time") cacheTime: Int?,
+        @Field("is_personal") isPersonal: Boolean,
+        @Field("next_offset") nextOffset: String?,
+        @Field("switch_pm_text") switchPmText: String?,
+        @Field("switch_pm_parameter") switchPmParameter: String?
+    ): Call<Response<Boolean>>
 }
 
 class LabeledPriceList(private val labeledPrice: List<LabeledPrice>) {

--- a/telegram/src/main/kotlin/me/ivmg/telegram/network/adapter/InlineQueryResultAdapter.kt
+++ b/telegram/src/main/kotlin/me/ivmg/telegram/network/adapter/InlineQueryResultAdapter.kt
@@ -1,0 +1,55 @@
+package me.ivmg.telegram.network.adapter
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonSerializationContext
+import com.google.gson.JsonSerializer
+import java.lang.reflect.Type
+import me.ivmg.telegram.entities.inlinequeryresults.InlineQueryResult
+import me.ivmg.telegram.entities.inlinequeryresults.InlineQueryResult.Article
+import me.ivmg.telegram.entities.inlinequeryresults.InlineQueryResult.Audio
+import me.ivmg.telegram.entities.inlinequeryresults.InlineQueryResult.CachedAudio
+import me.ivmg.telegram.entities.inlinequeryresults.InlineQueryResult.CachedDocument
+import me.ivmg.telegram.entities.inlinequeryresults.InlineQueryResult.CachedGif
+import me.ivmg.telegram.entities.inlinequeryresults.InlineQueryResult.CachedMpeg4Gif
+import me.ivmg.telegram.entities.inlinequeryresults.InlineQueryResult.CachedSticker
+import me.ivmg.telegram.entities.inlinequeryresults.InlineQueryResult.CachedVideo
+import me.ivmg.telegram.entities.inlinequeryresults.InlineQueryResult.CachedVoice
+import me.ivmg.telegram.entities.inlinequeryresults.InlineQueryResult.Contact
+import me.ivmg.telegram.entities.inlinequeryresults.InlineQueryResult.Document
+import me.ivmg.telegram.entities.inlinequeryresults.InlineQueryResult.Game
+import me.ivmg.telegram.entities.inlinequeryresults.InlineQueryResult.Gif
+import me.ivmg.telegram.entities.inlinequeryresults.InlineQueryResult.Location
+import me.ivmg.telegram.entities.inlinequeryresults.InlineQueryResult.Mpeg4Gif
+import me.ivmg.telegram.entities.inlinequeryresults.InlineQueryResult.Photo
+import me.ivmg.telegram.entities.inlinequeryresults.InlineQueryResult.Venue
+import me.ivmg.telegram.entities.inlinequeryresults.InlineQueryResult.Video
+import me.ivmg.telegram.entities.inlinequeryresults.InlineQueryResult.Voice
+
+class InlineQueryResultAdapter : JsonSerializer<InlineQueryResult> {
+
+    override fun serialize(
+        src: InlineQueryResult,
+        typeOfSrc: Type,
+        context: JsonSerializationContext
+    ): JsonElement = when (src) {
+        is Article -> context.serialize(src, Article::class.java)
+        is Photo -> context.serialize(src, Photo::class.java)
+        is Gif -> context.serialize(src, Gif::class.java)
+        is Mpeg4Gif -> context.serialize(src, Mpeg4Gif::class.java)
+        is Video -> context.serialize(src, Video::class.java)
+        is Audio -> context.serialize(src, Audio::class.java)
+        is Voice -> context.serialize(src, Voice::class.java)
+        is Document -> context.serialize(src, Document::class.java)
+        is Location -> context.serialize(src, Location::class.java)
+        is Venue -> context.serialize(src, Venue::class.java)
+        is Contact -> context.serialize(src, Contact::class.java)
+        is Game -> context.serialize(src, Game::class.java)
+        is CachedAudio -> context.serialize(src, CachedAudio::class.java)
+        is CachedDocument -> context.serialize(src, CachedDocument::class.java)
+        is CachedGif -> context.serialize(src, CachedGif::class.java)
+        is CachedMpeg4Gif -> context.serialize(src, CachedMpeg4Gif::class.java)
+        is CachedSticker -> context.serialize(src, CachedSticker::class.java)
+        is CachedVideo -> context.serialize(src, CachedVideo::class.java)
+        is CachedVoice -> context.serialize(src, CachedVoice::class.java)
+    }
+}


### PR DESCRIPTION
As requested per #33, in this PR you'll see the changes needed to fully support telegram bot's inline mode as specified in telegram bot api documentation (https://core.telegram.org/bots/api#inline-mode). The main changes you'll see here are the next:

- New entities needed to support API operations related with inline mode. You can check them at `InlineQueryResult.kt` and `InlineMessageContent.kt` files.

- `anwerInlineRequest` API operation. You can check the changes in `ApiClient.kt` and `Bot.kt`. Moreover, other change has been needed to support this API operation; a custom serializer for `InlineQueryResult` entity. You can check it at `InlineQueryResultAdapter.kt`

- New handler for inline queries. You can check the changes at `Callbacks.kt`, `Dispatcher.kt` and `InlineQueryHandler.kt` files.

- Finally, an inline query sample has been added to showcase how to use it.