### PR TITLE
Downgraded logging-interceptor

### DIFF
--- a/telegram/build.gradle
+++ b/telegram/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
     ext.retrofit_version = '2.3.0'
     ext.junit_version = "5.5.1"
-    ext.logging_interceptor_version = '4.3.1'
+    ext.logging_interceptor_version = '3.8.0'
 
     repositories {
         mavenCentral()

--- a/telegram/build.gradle
+++ b/telegram/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
     ext.retrofit_version = '2.3.0'
     ext.junit_version = "5.5.1"
-    ext.logging_interceptor_version = '3.9.1'
+    ext.logging_interceptor_version = '4.3.1'
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
Your retrofit dependency is using `okhttp` library version 4.3.1
Since your okhttp logging interceptor is older it throws an error each time I start the bot:
```
Exception in thread "pool-1-thread-2" java.lang.NoSuchMethodError: okhttp3.internal.platform.Platform.log(ILjava/lang/String;Ljava/lang/Throwable;)V
	at okhttp3.logging.HttpLoggingInterceptor$Logger$1.log(HttpLoggingInterceptor.java:110)
	at okhttp3.logging.HttpLoggingInterceptor.intercept(HttpLoggingInterceptor.java:160)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:112)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:87)
	at okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.kt:194)
	at okhttp3.RealCall.execute(RealCall.kt:67)
	at retrofit2.OkHttpCall.execute(OkHttpCall.java:180)
	at me.ivmg.telegram.network.UtilsKt.call(Utils.kt:8)
	at me.ivmg.telegram.Bot.getUpdates(Bot.kt:70)
	at me.ivmg.telegram.Updater.updaterStartPolling(Updater.kt:22)
	at me.ivmg.telegram.Updater.access$updaterStartPolling(Updater.kt:8)
	at me.ivmg.telegram.Updater$startPolling$2.run(Updater.kt:17)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```

I don't know why you don't have a similar issue, but I fixed in my project by bumping up logging-interceptor version