### PR TITLE
remove ReplyMarkup type from InlineKeyboardButton

### DIFF
--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/InlineKeyboardButton.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/InlineKeyboardButton.kt
@@ -8,4 +8,4 @@ data class InlineKeyboardButton(
     @Name("callback_data") val callbackData: String? = null,
     @Name("switch_inline_query") val switchInlineQuery: String? = null,
     @Name("switch_inline_query_current_chat") val switchInlineQueryCurrentChat: String? = null
-) : ReplyMarkup
+)


### PR DESCRIPTION
Looks like InlineKeyboardButton cannot be used for ReplyMarkup directly for bot.sendMessage

`{"ok":false,"error_code":400,"description":"Bad Request: can't parse reply keyboard markup JSON object"}`