### PR TITLE
Update 'ChatMember' class

### DIFF
--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/ChatMember.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/ChatMember.kt
@@ -1,23 +1,25 @@
 package com.github.kotlintelegrambot.entities
 
-import com.google.gson.annotations.SerializedName as Name
+import com.google.gson.annotations.SerializedName
 
 data class ChatMember(
-    val user: User,
-    val status: String,
-    @Name("until_date") val forceReply: Int? = null,
-    @Name("can_be_edited") val canBeEdited: Boolean? = null,
-    @Name("can_change_info") val canChangeInfo: Boolean? = null,
-    @Name("can_post_messages") val canPostMessages: Boolean? = null,
-    @Name("can_edit_messages") val canEditMessages: Boolean? = null,
-    @Name("can_delete_messages") val canDeleteMessages: Boolean? = null,
-    @Name("can_invite_users") val canInviteUsers: Boolean? = null,
-    @Name("can_restrict_members") val canRestrictMembers: Boolean? = null,
-    @Name("can_pin_messages") val canPinMessages: Boolean? = null,
-    @Name("is_member") val isMember: Boolean? = null,
-    @Name("can_promote_members") val canPromoteMembers: Boolean? = null,
-    @Name("can_send_messages") val canSendMessages: Boolean? = null,
-    @Name("can_send_media_messages") val canSendMediaMessages: Boolean? = null,
-    @Name("can_send_other_messages") val canSendOtherMessages: Boolean? = null,
-    @Name("can_add_web_page_previews") val canAddWebPagePreviews: Boolean? = null
+    @SerializedName("user") val user: User,
+    @SerializedName("status") val status: String,
+    @SerializedName("custom_title") val customTitle: String? = null,
+    @SerializedName("until_date") val forceReply: Int? = null,
+    @SerializedName("can_be_edited") val canBeEdited: Boolean? = null,
+    @SerializedName("can_post_messages") val canPostMessages: Boolean? = null,
+    @SerializedName("can_edit_messages") val canEditMessages: Boolean? = null,
+    @SerializedName("can_delete_messages") val canDeleteMessages: Boolean? = null,
+    @SerializedName("can_restrict_members") val canRestrictMembers: Boolean? = null,
+    @SerializedName("can_promote_members") val canPromoteMembers: Boolean? = null,
+    @SerializedName("can_change_info") val canChangeInfo: Boolean? = null,
+    @SerializedName("can_invite_users") val canInviteUsers: Boolean? = null,
+    @SerializedName("can_pin_messages") val canPinMessages: Boolean? = null,
+    @SerializedName("is_member") val isMember: Boolean? = null,
+    @SerializedName("can_send_messages") val canSendMessages: Boolean? = null,
+    @SerializedName("can_send_media_messages") val canSendMediaMessages: Boolean? = null,
+    @SerializedName("can_send_polls") val canSendPolls: Boolean? = null,
+    @SerializedName("can_send_other_messages") val canSendOtherMessages: Boolean? = null,
+    @SerializedName("can_add_web_page_previews") val canAddWebPagePreviews: Boolean? = null
 )


### PR DESCRIPTION
As per #66, the missing fields `custom_title` and `can_send_polls` has been added to the `ChatMember` class. Also, all of its fields have been annotated with `@SerializedName` for consistency's sake