### PR TITLE
Add 'sendDice' operation and 'dice' field to 'Message'

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ dependencies {
 
 1. [Getting updates](https://github.com/kotlin-telegram-bot/kotlin-telegram-bot/tree/master/docs/gettingUpdates.md)
 2. [Polls](https://github.com/kotlin-telegram-bot/kotlin-telegram-bot/tree/master/docs/polls.md)
+3. [Dice](https://github.com/kotlin-telegram-bot/kotlin-telegram-bot/tree/master/docs/dice.md)
 
 ## Contributing
 

--- a/docs/dice.md
+++ b/docs/dice.md
@@ -1,0 +1,35 @@
+# Dice
+
+The Telegram Bot API offers one operation to send a die (dice) to a given chat. The operation is called `sendDice` and in this library you can use it by directly calling the `sendDice` method of a bot instance. For example, you can send a dice in the next way: 
+
+```kotlin
+val bot = bot {
+    token = BOT_API_TOKEN
+    // additional configuration
+}
+
+bot.sendDice(ANY_CHAT_ID)
+```
+
+The operation also let you customize the emoji that will be used for the dice (currently 🎲 or 🎯). You can customize it in the next way:
+
+```kotlin
+// to send the dice with a dice emoji
+bot.sendDice(ANY_CHAT_ID, DiceEmoji.Dice)
+
+// to send the dice with a dartboard emoji
+bot.sendDice(ANY_CHAT_ID, DiceEmoji.Dartboard)
+```
+
+Moreover, it's also possible to listen to dice messages. These dice messages come within an update object and you can listen to them with the library's DSL in the next way:
+
+```kotlin
+bot {
+    token = BOT_API_TOKEN
+    dispatch {
+        dice { bot, message, update ->
+            // do whatever you want with the dice message
+        }               
+    }
+}
+```

--- a/samples/dispatcher/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Main.kt
+++ b/samples/dispatcher/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Main.kt
@@ -9,6 +9,7 @@ import com.github.kotlintelegrambot.entities.KeyboardReplyMarkup
 import com.github.kotlintelegrambot.entities.ParseMode.MARKDOWN
 import com.github.kotlintelegrambot.entities.ReplyKeyboardRemove
 import com.github.kotlintelegrambot.entities.TelegramFile.ByUrl
+import com.github.kotlintelegrambot.entities.dice.DiceEmoji
 import com.github.kotlintelegrambot.entities.inlinequeryresults.InlineQueryResult
 import com.github.kotlintelegrambot.entities.inlinequeryresults.InputMessageContent
 import com.github.kotlintelegrambot.entities.inputmedia.InputMediaPhoto
@@ -164,6 +165,15 @@ fun main(args: Array<String>) {
                     chatId = chatId,
                     text = "Wowww, awesome photos!!! :P"
                 )
+            }
+
+            command("diceAsDartboard") { bot, update ->
+                val chatId = update.message?.chat?.id ?: return@command
+                bot.sendDice(chatId, DiceEmoji.Dartboard)
+            }
+
+            dice { bot, message, dice ->
+                bot.sendMessage(message.chat.id, "A dice ${dice.emoji.emojiValue} with value ${dice.value} has been received!")
             }
 
             telegramError { _, telegramError ->

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -9,6 +9,7 @@ import com.github.kotlintelegrambot.entities.ParseMode
 import com.github.kotlintelegrambot.entities.ReplyMarkup
 import com.github.kotlintelegrambot.entities.TelegramFile
 import com.github.kotlintelegrambot.entities.Update
+import com.github.kotlintelegrambot.entities.dice.DiceEmoji
 import com.github.kotlintelegrambot.entities.inlinequeryresults.InlineQueryResult
 import com.github.kotlintelegrambot.entities.inputmedia.InputMedia
 import com.github.kotlintelegrambot.entities.inputmedia.MediaGroup
@@ -1116,4 +1117,50 @@ class Bot private constructor(
     ).call()
 
     fun getMyCommands() = apiClient.getMyCommands().call()
+
+    /**
+     * Use this method to send a dice, which will have a random value from 1 to 6.
+     * @param chatId Unique identifier for the target chat
+     * @param emoji Emoji on which the dice throw animation is based. Currently, must be one of 🎲 or 🎯. Defaults to 🎲
+     * @param disableNotification Sends the message silently. Users will receive a notification with no sound
+     * @param replyToMessageId If the message is a reply, ID of the original message
+     * @param replyMarkup A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user
+     * @return the sent Message
+     */
+    fun sendDice(
+        chatId: Long,
+        emoji: DiceEmoji? = null,
+        disableNotification: Boolean? = null,
+        replyToMessageId: Long? = null,
+        replyMarkup: ReplyMarkup? = null
+    ) = apiClient.sendDice(
+        chatId,
+        emoji,
+        disableNotification,
+        replyToMessageId,
+        replyMarkup
+    ).call()
+
+    /**
+     * Use this method to send a dice, which will have a random value from 1 to 6.
+     * @param channelUsername Username of the target channel (in the format @channelusername)
+     * @param emoji Emoji on which the dice throw animation is based. Currently, must be one of 🎲 or 🎯. Defaults to 🎲
+     * @param disableNotification Sends the message silently. Users will receive a notification with no sound
+     * @param replyToMessageId If the message is a reply, ID of the original message
+     * @param replyMarkup A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user
+     * @return the sent Message
+     */
+    fun sendDice(
+        channelUsername: String,
+        emoji: DiceEmoji? = null,
+        disableNotification: Boolean? = null,
+        replyToMessageId: Long? = null,
+        replyMarkup: ReplyMarkup? = null
+    ) = apiClient.sendDice(
+        channelUsername,
+        emoji,
+        disableNotification,
+        replyToMessageId,
+        replyMarkup
+    ).call()
 }

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Callbacks.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Callbacks.kt
@@ -14,6 +14,7 @@ import com.github.kotlintelegrambot.entities.User
 import com.github.kotlintelegrambot.entities.Video
 import com.github.kotlintelegrambot.entities.VideoNote
 import com.github.kotlintelegrambot.entities.Voice
+import com.github.kotlintelegrambot.entities.dice.Dice
 import com.github.kotlintelegrambot.entities.polls.PollAnswer
 import com.github.kotlintelegrambot.entities.stickers.Sticker
 import com.github.kotlintelegrambot.errors.TelegramError
@@ -33,6 +34,8 @@ typealias HandleInlineQuery = (Bot, InlineQuery) -> Unit
 typealias HandleNewChatMembers = (Bot, Message, List<User>) -> Unit
 
 typealias HandlePollAnswer = (Bot, PollAnswer) -> Unit
+
+typealias HandleDice = (Bot, Message, Dice) -> Unit
 
 typealias HandleAudioUpdate = (Bot, Update, Audio) -> Unit
 typealias HandleDocumentUpdate = (Bot, Update, Document) -> Unit

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Dispatcher.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Dispatcher.kt
@@ -5,6 +5,7 @@ import com.github.kotlintelegrambot.CommandHandleUpdate
 import com.github.kotlintelegrambot.ContactHandleUpdate
 import com.github.kotlintelegrambot.HandleAnimationUpdate
 import com.github.kotlintelegrambot.HandleAudioUpdate
+import com.github.kotlintelegrambot.HandleDice
 import com.github.kotlintelegrambot.HandleDocumentUpdate
 import com.github.kotlintelegrambot.HandleError
 import com.github.kotlintelegrambot.HandleGameUpdate
@@ -23,6 +24,7 @@ import com.github.kotlintelegrambot.dispatcher.handlers.ChannelHandler
 import com.github.kotlintelegrambot.dispatcher.handlers.CheckoutHandler
 import com.github.kotlintelegrambot.dispatcher.handlers.CommandHandler
 import com.github.kotlintelegrambot.dispatcher.handlers.ContactHandler
+import com.github.kotlintelegrambot.dispatcher.handlers.DiceHandler
 import com.github.kotlintelegrambot.dispatcher.handlers.Handler
 import com.github.kotlintelegrambot.dispatcher.handlers.InlineQueryHandler
 import com.github.kotlintelegrambot.dispatcher.handlers.LocationHandler
@@ -136,6 +138,10 @@ fun Dispatcher.newChatMembers(body: HandleNewChatMembers) {
 
 fun Dispatcher.pollAnswer(body: HandlePollAnswer) {
     addHandler(PollAnswerHandler(body))
+}
+
+fun Dispatcher.dice(body: HandleDice) {
+    addHandler(DiceHandler(body))
 }
 
 class Dispatcher(

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/DiceHandler.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/DiceHandler.kt
@@ -1,0 +1,22 @@
+package com.github.kotlintelegrambot.dispatcher.handlers
+
+import com.github.kotlintelegrambot.Bot
+import com.github.kotlintelegrambot.HandleDice
+import com.github.kotlintelegrambot.HandleUpdate
+import com.github.kotlintelegrambot.entities.Update
+
+internal class DiceHandler(handleDice: HandleDice) : Handler(HandleDiceProxy(handleDice)) {
+    override val groupIdentifier: String
+        get() = "dice"
+
+    override fun checkUpdate(update: Update): Boolean = update.message?.dice != null
+}
+
+private class HandleDiceProxy(private val handleDice: HandleDice) : HandleUpdate {
+    override fun invoke(bot: Bot, update: Update) {
+        val message = update.message
+        val dice = message?.dice
+        checkNotNull(dice)
+        handleDice.invoke(bot, message, dice)
+    }
+}

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/Message.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/Message.kt
@@ -1,5 +1,6 @@
 package com.github.kotlintelegrambot.entities
 
+import com.github.kotlintelegrambot.entities.dice.Dice
 import com.github.kotlintelegrambot.entities.payments.SuccessfulPayment
 import com.github.kotlintelegrambot.entities.polls.Poll
 import com.github.kotlintelegrambot.entities.stickers.Sticker
@@ -24,6 +25,7 @@ data class Message(
     val audio: Audio? = null,
     val document: Document? = null,
     val animation: Animation? = null,
+    @Name("dice") val dice: Dice? = null,
     val game: Game? = null,
     val photo: List<PhotoSize>? = null,
     val sticker: Sticker? = null,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/dice/Dice.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/dice/Dice.kt
@@ -1,0 +1,38 @@
+package com.github.kotlintelegrambot.entities.dice
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Represents a dice with a random value from 1 to 6 for currently supported base emoji.
+ * https://core.telegram.org/bots/api#dice
+ */
+data class Dice(
+    @SerializedName(DiceFields.EMOJI) val emoji: DiceEmoji,
+    @SerializedName(DiceFields.VALUE) val value: Int
+)
+
+sealed class DiceEmoji {
+    abstract val emojiValue: String
+
+    object Dice : DiceEmoji() {
+        override val emojiValue: String
+            get() = "🎲"
+    }
+
+    object Dartboard : DiceEmoji() {
+        override val emojiValue: String
+            get() = "🎯"
+    }
+
+    // Currently not supported, adding it just in case Telegram Bot API
+    // starts supporting new emojis for the dice in the future
+    data class Other(override val emojiValue: String) : DiceEmoji()
+
+    companion object {
+        fun fromString(emoji: String): DiceEmoji = when (emoji) {
+            Dice.emojiValue -> Dice
+            Dartboard.emojiValue -> Dartboard
+            else -> Other(emoji)
+        }
+    }
+}

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/dice/DiceFields.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/dice/DiceFields.kt
@@ -1,0 +1,7 @@
+package com.github.kotlintelegrambot.entities.dice
+
+internal object DiceFields {
+    const val SEND_DICE_OP_NAME = "sendDice"
+    const val EMOJI = "emoji"
+    const val VALUE = "value"
+}

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -18,6 +18,7 @@ import com.github.kotlintelegrambot.entities.Update
 import com.github.kotlintelegrambot.entities.User
 import com.github.kotlintelegrambot.entities.UserProfilePhotos
 import com.github.kotlintelegrambot.entities.WebhookInfo
+import com.github.kotlintelegrambot.entities.dice.DiceEmoji
 import com.github.kotlintelegrambot.entities.inlinequeryresults.InlineQueryResult
 import com.github.kotlintelegrambot.entities.inputmedia.InputMedia
 import com.github.kotlintelegrambot.entities.inputmedia.MediaGroup
@@ -29,6 +30,7 @@ import com.github.kotlintelegrambot.entities.stickers.MaskPosition
 import com.github.kotlintelegrambot.entities.stickers.StickerSet
 import com.github.kotlintelegrambot.network.multipart.MultipartBodyFactory
 import com.github.kotlintelegrambot.network.multipart.toMultipartBodyPart
+import com.github.kotlintelegrambot.network.retrofit.converters.DiceEmojiConverterFactory
 import com.github.kotlintelegrambot.network.retrofit.converters.EnumRetrofitConverterFactory
 import com.github.kotlintelegrambot.network.serialization.GsonFactory
 import com.google.gson.Gson
@@ -121,6 +123,7 @@ class ApiClient(
             // with BuiltInConverters.ToStringConverter which just calls to the toString() method of a given object.
             // Is needed to provide a special Converter.Factory if a custom transformation is wanted for them.
             .addConverterFactory(EnumRetrofitConverterFactory())
+            .addConverterFactory(DiceEmojiConverterFactory())
             .build()
 
         service = retrofit.create(ApiService::class.java)
@@ -1293,4 +1296,32 @@ class ApiClient(
     fun setMyCommands(commands: List<BotCommand>): Call<Response<Boolean>> {
         return service.setMyCommands(gson.toJson(commands))
     }
+
+    fun sendDice(
+        chatId: Long,
+        emoji: DiceEmoji? = null,
+        disableNotification: Boolean? = null,
+        replyToMessageId: Long? = null,
+        replyMarkup: ReplyMarkup? = null
+    ): Call<Response<Message>> = service.sendDice(
+        chatId,
+        emoji,
+        disableNotification,
+        replyToMessageId,
+        replyMarkup
+    )
+
+    fun sendDice(
+        channelUsername: String,
+        emoji: DiceEmoji? = null,
+        disableNotification: Boolean? = null,
+        replyToMessageId: Long? = null,
+        replyMarkup: ReplyMarkup? = null
+    ): Call<Response<Message>> = service.sendDice(
+        channelUsername,
+        emoji,
+        disableNotification,
+        replyToMessageId,
+        replyMarkup
+    )
 }

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
@@ -13,6 +13,8 @@ import com.github.kotlintelegrambot.entities.Update
 import com.github.kotlintelegrambot.entities.User
 import com.github.kotlintelegrambot.entities.UserProfilePhotos
 import com.github.kotlintelegrambot.entities.WebhookInfo
+import com.github.kotlintelegrambot.entities.dice.DiceEmoji
+import com.github.kotlintelegrambot.entities.dice.DiceFields
 import com.github.kotlintelegrambot.entities.inputmedia.InputMedia
 import com.github.kotlintelegrambot.entities.payments.LabeledPrice
 import com.github.kotlintelegrambot.entities.payments.ShippingOption
@@ -787,6 +789,26 @@ interface ApiService {
     fun setMyCommands(
         @Field("commands") commands: String
     ): Call<Response<Boolean>>
+
+    @FormUrlEncoded
+    @POST(DiceFields.SEND_DICE_OP_NAME)
+    fun sendDice(
+        @Field(ApiConstants.CHAT_ID) chatId: Long,
+        @Field(DiceFields.EMOJI) emoji: DiceEmoji? = null,
+        @Field(ApiConstants.DISABLE_NOTIFICATION) disableNotification: Boolean? = null,
+        @Field(ApiConstants.REPLY_TO_MESSAGE_ID) replyToMessageId: Long? = null,
+        @Field(ApiConstants.REPLY_MARKUP) replyMarkup: ReplyMarkup? = null
+    ): Call<Response<Message>>
+
+    @FormUrlEncoded
+    @POST(DiceFields.SEND_DICE_OP_NAME)
+    fun sendDice(
+        @Field(ApiConstants.CHAT_ID) channelUsername: String,
+        @Field(DiceFields.EMOJI) emoji: DiceEmoji? = null,
+        @Field(ApiConstants.DISABLE_NOTIFICATION) disableNotification: Boolean? = null,
+        @Field(ApiConstants.REPLY_TO_MESSAGE_ID) replyToMessageId: Long? = null,
+        @Field(ApiConstants.REPLY_MARKUP) replyMarkup: ReplyMarkup? = null
+    ): Call<Response<Message>>
 }
 
 class LabeledPriceList(private val labeledPrice: List<LabeledPrice>) {

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/retrofit/converters/DiceEmojiConverterFactory.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/retrofit/converters/DiceEmojiConverterFactory.kt
@@ -1,0 +1,20 @@
+package com.github.kotlintelegrambot.network.retrofit.converters
+
+import com.github.kotlintelegrambot.entities.dice.DiceEmoji
+import java.lang.reflect.Type
+import retrofit2.Converter
+import retrofit2.Retrofit
+
+class DiceEmojiConverterFactory : Converter.Factory() {
+
+    override fun stringConverter(type: Type?, annotations: Array<out Annotation>?, retrofit: Retrofit?): Converter<DiceEmoji, String>? {
+        val clazz = type as? Class<*> ?: return null
+        val diceEmojiSuperclass = DiceEmoji::class.java
+
+        if (clazz != diceEmojiSuperclass && clazz.genericSuperclass != diceEmojiSuperclass) {
+            return null
+        }
+
+        return Converter { diceEmoji: DiceEmoji -> diceEmoji.emojiValue }
+    }
+}

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/serialization/GsonFactory.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/serialization/GsonFactory.kt
@@ -1,8 +1,10 @@
 package com.github.kotlintelegrambot.network.serialization
 
 import com.github.kotlintelegrambot.entities.TelegramFile
+import com.github.kotlintelegrambot.entities.dice.DiceEmoji
 import com.github.kotlintelegrambot.entities.inlinequeryresults.InlineQueryResult
 import com.github.kotlintelegrambot.entities.inputmedia.GroupableMedia
+import com.github.kotlintelegrambot.network.serialization.adapter.DiceEmojiAdapter
 import com.github.kotlintelegrambot.network.serialization.adapter.GroupableMediaAdapter
 import com.github.kotlintelegrambot.network.serialization.adapter.InlineQueryResultAdapter
 import com.github.kotlintelegrambot.network.serialization.adapter.InputMediaAdapter
@@ -14,6 +16,7 @@ object GsonFactory {
 
     fun createForApiClient(): Gson = GsonBuilder()
         .registerTypeAdapter(InlineQueryResult::class.java, InlineQueryResultAdapter())
+        .registerTypeAdapter(DiceEmoji::class.java, DiceEmojiAdapter())
         .create()
 
     fun createForMultipartBodyFactory(): Gson = GsonBuilder()

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/serialization/adapter/DiceEmojiAdapter.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/serialization/adapter/DiceEmojiAdapter.kt
@@ -1,0 +1,12 @@
+package com.github.kotlintelegrambot.network.serialization.adapter
+
+import com.github.kotlintelegrambot.entities.dice.DiceEmoji
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import java.lang.reflect.Type
+
+class DiceEmojiAdapter : JsonDeserializer<DiceEmoji> {
+    override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext?): DiceEmoji =
+        DiceEmoji.fromString(json.asString)
+}

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendDiceIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendDiceIT.kt
@@ -1,0 +1,131 @@
+package com.github.kotlintelegrambot.network.apiclient
+
+import com.github.kotlintelegrambot.entities.Chat
+import com.github.kotlintelegrambot.entities.Message
+import com.github.kotlintelegrambot.entities.User
+import com.github.kotlintelegrambot.entities.dice.Dice
+import com.github.kotlintelegrambot.entities.dice.DiceEmoji
+import com.github.kotlintelegrambot.testutils.decode
+import junit.framework.TestCase.assertEquals
+import okhttp3.mockwebserver.MockResponse
+import org.junit.jupiter.api.Test
+
+class SendDiceIT : ApiClientIT() {
+
+    @Test
+    fun `sendDice only with mandatory parameters`() {
+        givenAnySendDiceResponse()
+
+        sut.sendDice(ANY_CHAT_ID).execute()
+
+        val request = mockWebServer.takeRequest()
+        val expectedRequestBody = "chat_id=$ANY_CHAT_ID"
+        assertEquals(expectedRequestBody, request.body.readUtf8().decode())
+    }
+
+    @Test
+    fun `sendDice with dice emoji`() {
+        givenAnySendDiceResponse()
+
+        sut.sendDice(ANY_CHAT_ID, emoji = DiceEmoji.Dice).execute()
+
+        val request = mockWebServer.takeRequest()
+        val expectedRequestBody = "chat_id=$ANY_CHAT_ID&emoji=🎲"
+        assertEquals(expectedRequestBody, request.body.readUtf8().decode())
+    }
+
+    @Test
+    fun `sendDice with dartboard emoji`() {
+        givenAnySendDiceResponse()
+
+        sut.sendDice(ANY_CHAT_ID, emoji = DiceEmoji.Dartboard).execute()
+
+        val request = mockWebServer.takeRequest()
+        val expectedRequestBody = "chat_id=$ANY_CHAT_ID&emoji=🎯"
+        assertEquals(expectedRequestBody, request.body.readUtf8().decode())
+    }
+
+    @Test
+    fun `sendDice with all the optional parameters`() {
+        givenAnySendDiceResponse()
+
+        sut.sendDice(
+            ANY_CHAT_ID,
+            emoji = DiceEmoji.Dartboard,
+            disableNotification = DISABLE_NOTIFICATION,
+            replyToMessageId = ANY_MESSAGE_ID
+        ).execute()
+
+        val request = mockWebServer.takeRequest()
+        val expectedRequestBody = "chat_id=$ANY_CHAT_ID" +
+                "&emoji=🎯" +
+                "&disable_notification=$DISABLE_NOTIFICATION" +
+                "&reply_to_message_id=$ANY_MESSAGE_ID"
+        assertEquals(expectedRequestBody, request.body.readUtf8().decode())
+    }
+
+    @Test
+    fun `sendDice response is correctly returned`() {
+        givenAnySendDiceResponse()
+
+        val sendDiceResult = sut.sendDice(ANY_CHAT_ID, emoji = DiceEmoji.Dartboard).execute()
+
+        val expectedMessage = Message(
+            messageId = 56,
+            from = User(
+                id = 482352699,
+                isBot = true,
+                firstName = "foo",
+                username = "bar"
+            ),
+            chat = Chat(
+                id = -1001287972005,
+                title = "Test Telegram Bot API",
+                type = "supergroup"
+            ),
+            date = 1590313567,
+            dice = Dice(
+                emoji = DiceEmoji.Dartboard,
+                value = 6
+            )
+        )
+        assertEquals(expectedMessage, sendDiceResult.body()?.result)
+    }
+
+    private fun givenAnySendDiceResponse() {
+        val sendDiceResponse = """
+            {
+                "ok": true,
+                "result": {
+                    "message_id": 56,
+                    "from": {
+                        "id": 482352699,
+                        "is_bot": true,
+                        "first_name": "foo",
+                        "username": "bar"
+                    },
+                    "chat": {
+                        "id": -1001287972005,
+                        "title": "Test Telegram Bot API",
+                        "type": "supergroup"
+                    },
+                    "date": 1590313567,
+                    "dice": {
+                        "emoji": "🎯",
+                        "value": 6
+                    }
+                }
+            }
+        """.trimIndent()
+        val mockedResponse = MockResponse()
+            .setResponseCode(200)
+            .setBody(sendDiceResponse)
+        mockWebServer.enqueue(mockedResponse)
+    }
+
+    private companion object {
+        const val ANY_CHAT_ID = 2351353153L
+        const val DISABLE_NOTIFICATION = true
+        const val ANY_MESSAGE_ID = 3152321342L
+    }
+}

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/retrofit/converters/DiceEmojiConverterFactoryTest.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/retrofit/converters/DiceEmojiConverterFactoryTest.kt
@@ -1,0 +1,58 @@
+package com.github.kotlintelegrambot.network.retrofit.converters
+
+import com.github.kotlintelegrambot.entities.Message
+import com.github.kotlintelegrambot.entities.dice.DiceEmoji
+import io.mockk.mockk
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNull
+import org.junit.jupiter.api.Test
+import retrofit2.Retrofit
+
+class DiceEmojiConverterFactoryTest {
+
+    private val retrofitMock = mockk<Retrofit>()
+    private val sut = DiceEmojiConverterFactory()
+
+    @Test
+    fun `returns a null converter when the input type is not DiceEmoji`() {
+        val stringConverterForInt = sut.stringConverter(Int::class.java, emptyArray(), retrofitMock)
+        val stringConverterForCharSequence = sut.stringConverter(CharSequence::class.java, emptyArray(), retrofitMock)
+        val stringConverterForMessage = sut.stringConverter(Message::class.java, emptyArray(), retrofitMock)
+
+        assertNull(stringConverterForInt)
+        assertNull(stringConverterForCharSequence)
+        assertNull(stringConverterForMessage)
+    }
+
+    @Test
+    fun `returns a converter that transforms DiceEmoji to correspondent emoji string when the input type is DiceEmoji`() {
+        val genericStringConverter = sut.stringConverter(DiceEmoji::class.java, emptyArray(), retrofitMock)
+
+        assertEquals(DiceEmoji.Dice.emojiValue, genericStringConverter?.convert(DiceEmoji.Dice))
+        assertEquals(DiceEmoji.Dartboard.emojiValue, genericStringConverter?.convert(DiceEmoji.Dartboard))
+        val anyOtherEmoji = "\uD83D\uDE31" // face screaming emoji -> 😱
+        assertEquals(anyOtherEmoji, genericStringConverter?.convert(DiceEmoji.Other(anyOtherEmoji)))
+    }
+
+    @Test
+    fun `returns a converter that transforms Dice to correspondent emoji string when the input type is Dice`() {
+        val stringConverterForDice = sut.stringConverter(DiceEmoji.Dice::class.java, emptyArray(), retrofitMock)
+
+        assertEquals(DiceEmoji.Dice.emojiValue, stringConverterForDice?.convert(DiceEmoji.Dice))
+    }
+
+    @Test
+    fun `returns a converter that transforms Dartboard to correspondent emoji string when the input type is Dartboard`() {
+        val stringConverterForDartboard = sut.stringConverter(DiceEmoji.Dartboard::class.java, emptyArray(), retrofitMock)
+
+        assertEquals(DiceEmoji.Dartboard.emojiValue, stringConverterForDartboard?.convert(DiceEmoji.Dartboard))
+    }
+
+    @Test
+    fun `returns a converter that transforms Other to correspondent emoji string when the input type is Other`() {
+        val stringConverterForOther = sut.stringConverter(DiceEmoji.Other::class.java, emptyArray(), retrofitMock)
+
+        val anyOtherEmoji = "\uD83D\uDE31" // face screaming emoji -> 😱
+        assertEquals(anyOtherEmoji, stringConverterForOther?.convert(DiceEmoji.Other(anyOtherEmoji)))
+    }
+}

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/serialization/adapter/DiceEmojiAdapterTest.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/serialization/adapter/DiceEmojiAdapterTest.kt
@@ -1,0 +1,26 @@
+package com.github.kotlintelegrambot.network.serialization.adapter
+
+import com.github.kotlintelegrambot.entities.dice.Dice
+import com.github.kotlintelegrambot.entities.dice.DiceEmoji
+import com.google.gson.GsonBuilder
+import junit.framework.TestCase.assertEquals
+import org.junit.jupiter.api.Test
+
+class DiceEmojiAdapterTest {
+
+    @Test
+    fun `DiceEmoji arguments are correctly deserialized`() {
+        val sut = GsonBuilder().registerTypeAdapter(DiceEmoji::class.java, DiceEmojiAdapter()).create()
+
+        val diceJson = """
+                {
+                    "emoji": "🎲",
+                    "value": "5"
+                }
+            """.trimIndent()
+        val deserializedDice = sut.fromJson(diceJson, Dice::class.java)
+
+        val expectedEmoji = DiceEmoji.Dice
+        assertEquals(expectedEmoji, deserializedDice.emoji)
+    }
+}


### PR DESCRIPTION
In this PR you'll see the changes needed to implement the `sendDice` operation (https://core.telegram.org/bots/api#senddice) and to add the `dice` field to the `Message` model (https://core.telegram.org/bots/api#message).

The main changes are the next:
* Added the `sendDice` operation -> Changes on `Bot`, `ApiClient` and `ApiService`
* Added the `dice` field to the `Message` model
* Added a new handler for "dice messages"
* A new model have been created to represent the dice emoji, called `DiceEmoji`. `DiceEmoji` is a sealed class, extended by the `Dice` and `Dartboard` kotlin objects (representing the currently available dice emojis) and a class `Other` added just in case Telegram adds new emojis for the dice in the future. To deserialize (as a field of a `Dice` object) and serialize it (as a `sendDice` request body's field) a couple of adapters have been added. `DiceEmojiConverterFactory`, which is the one needed to serialize the dice emoji as a field for the request body and `DiceEmojiAdapter`, which is the one needed to deserialize the dice emoji as a field within the `Dice` object
* A new documentation page has been added with some information about how to use the new added features
* A few tests have been added to cover the API operation and the new needed adapters
* A pair of examples using the new features have been added to the `dispatcher` sample
