### PR TITLE
Update 'MessageEntity' model

### DIFF
--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/MessageEntity.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/MessageEntity.kt
@@ -1,9 +1,48 @@
 package com.github.kotlintelegrambot.entities
 
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Represents one special entity in a text message. For example, hashtags, usernames, URLs, etc.
+ */
 data class MessageEntity(
-    val type: String,
-    val offset: Int,
-    val length: Int,
-    val url: String? = null,
-    val user: User? = null
-)
+    @SerializedName("type") val type: Type,
+    @SerializedName("offset") val offset: Int,
+    @SerializedName("length") val length: Int,
+    @SerializedName("url") val url: String? = null,
+    @SerializedName("user") val user: User? = null,
+    @SerializedName("language") val language: String? = null
+) {
+    enum class Type {
+        @SerializedName("mention")
+        MENTION,
+        @SerializedName("hashtag")
+        HASHTAG,
+        @SerializedName("cashtag")
+        CASHTAG,
+        @SerializedName("bot_command")
+        BOT_COMMAND,
+        @SerializedName("url")
+        URL,
+        @SerializedName("email")
+        EMAIL,
+        @SerializedName("phone_number")
+        PHONE_NUMBER,
+        @SerializedName("bold")
+        BOLD,
+        @SerializedName("italic")
+        ITALIC,
+        @SerializedName("underline")
+        UNDERLINE,
+        @SerializedName("strikethrough")
+        STRIKETHROUGH,
+        @SerializedName("code")
+        CODE,
+        @SerializedName("pre")
+        PRE,
+        @SerializedName("text_link")
+        TEXT_LINK,
+        @SerializedName("text_mention")
+        TEXT_MENTION
+    }
+}

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/retrofit/converters/EnumRetrofitConverterFactoryTest.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/retrofit/converters/EnumRetrofitConverterFactoryTest.kt
@@ -20,6 +20,16 @@ class EnumRetrofitConverterFactoryTest {
         ENUM_A
     }
 
+    data class TestClass(
+        val testAttr: Int
+    ) {
+
+        enum class InnerEnum {
+            @SerializedName("enumA")
+            ENUM_A
+        }
+    }
+
     private val retrofitMock = mockk<Retrofit>()
     private val sut = EnumRetrofitConverterFactory()
 
@@ -48,5 +58,14 @@ class EnumRetrofitConverterFactoryTest {
 
         val expectedErrorMessage = "cannot serialize ${RegularEnum::class.java} enum properly, please make sure it's annotated with @SerializedName"
         assertEquals(expectedErrorMessage, error.message)
+    }
+
+    @Test
+    fun `inner enum with values annotated with @SerializedName is correctly transformed to String`() {
+        val stringConverter = sut.stringConverter(TestClass.InnerEnum::class.java, emptyArray(), retrofitMock)
+        val stringFromRegularEnum = stringConverter?.convert(TestClass.InnerEnum.ENUM_A)
+
+        val expectedString = "enumA"
+        assertEquals(expectedString, stringFromRegularEnum)
     }
 }


### PR DESCRIPTION
* Add 'language' field to 'MessageEntity' model.

* Represent 'type' field in 'MessageEntity' model with an enum class containing all the possible types instead of using a string.

* Add a test for 'EnumRetrofitConverterFactoryTest' to ensure that enums nested inside a class are correctly decoded.