### PR TITLE
Add support for MarkdownV2 parse mode

### DIFF
--- a/samples/dispatcher/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Main.kt
+++ b/samples/dispatcher/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Main.kt
@@ -7,6 +7,7 @@ import com.github.kotlintelegrambot.dispatcher.handlers.CallbackQueryHandler
 import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
 import com.github.kotlintelegrambot.entities.KeyboardReplyMarkup
 import com.github.kotlintelegrambot.entities.ParseMode.MARKDOWN
+import com.github.kotlintelegrambot.entities.ParseMode.MARKDOWN_V2
 import com.github.kotlintelegrambot.entities.ReplyKeyboardRemove
 import com.github.kotlintelegrambot.entities.TelegramFile.ByUrl
 import com.github.kotlintelegrambot.entities.dice.DiceEmoji
@@ -71,6 +72,29 @@ fun main(args: Array<String>) {
                     chatId = update.message!!.chat.id,
                     text = markdownText,
                     parseMode = MARKDOWN
+                )
+            }
+
+            command("markdownV2") { bot, update ->
+                val markdownV2Text = """
+                    *bold \*text*
+                    _italic \*text_
+                    __underline__
+                    ~strikethrough~
+                    *bold _italic bold ~italic bold strikethrough~ __underline italic bold___ bold*
+                    [inline URL](http://www.example.com/)
+                    [inline mention of a user](tg://user?id=123456789)
+                    `inline fixed-width code`
+                    ```kotlin
+                    fun main() {
+                        println("Hello Kotlin!")
+                    }
+                    ```
+                """.trimIndent()
+                bot.sendMessage(
+                    chatId = update.message!!.chat.id,
+                    text = markdownV2Text,
+                    parseMode = MARKDOWN_V2
                 )
             }
 

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/ParseMode.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/ParseMode.kt
@@ -5,5 +5,6 @@ import com.google.gson.annotations.SerializedName
 // TODO: Remove modeName attribute and stop using it as a serialization approach for this enum
 enum class ParseMode(val modeName: String) {
     @SerializedName("Markdown") MARKDOWN("Markdown"),
-    @SerializedName("HTML") HTML("HTML");
+    @SerializedName("HTML") HTML("HTML"),
+    @SerializedName("MarkdownV2") MARKDOWN_V2("MarkdownV2")
 }


### PR DESCRIPTION
* Add 'MarkdownV2' to 'ParseMode' enum.

* Add an example showcasing how to send a text message formatted with MarkdownV2.