### PR TITLE
Support bot api 4.9

### DIFF
--- a/docs/dice.md
+++ b/docs/dice.md
@@ -19,6 +19,9 @@ bot.sendDice(ANY_CHAT_ID, DiceEmoji.Dice)
 
 // to send the dice with a dartboard emoji
 bot.sendDice(ANY_CHAT_ID, DiceEmoji.Dartboard)
+
+// to send the dice with a basketball emoji
+bot.sendDice(ANY_CHAT_ID, DiceEmoji.Basketball)
 ```
 
 Moreover, it's also possible to listen to dice messages. These dice messages come within an update object and you can listen to them with the library's DSL in the next way:

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/Message.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/Message.kt
@@ -18,6 +18,7 @@ data class Message(
     @Name("forward_sender_name") val forwardSenderName: String? = null,
     @Name("forward_date") val forwardDate: Int? = null,
     @Name("reply_to_message") val replyToMessage: Message? = null,
+    @Name("via_bot") val viaBot: User? = null,
     @Name("edit_date") val editDate: Int? = null,
     val text: String? = null,
     val entities: List<MessageEntity>? = null,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/dice/Dice.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/dice/Dice.kt
@@ -3,7 +3,7 @@ package com.github.kotlintelegrambot.entities.dice
 import com.google.gson.annotations.SerializedName
 
 /**
- * Represents a dice with a random value from 1 to 6 for currently supported base emoji.
+ * Represents an animated emoji that displays a random value.
  * https://core.telegram.org/bots/api#dice
  */
 data class Dice(
@@ -24,6 +24,11 @@ sealed class DiceEmoji {
             get() = "🎯"
     }
 
+    object Basketball : DiceEmoji() {
+        override val emojiValue: String
+            get() = "🏀"
+    }
+
     // Currently not supported, adding it just in case Telegram Bot API
     // starts supporting new emojis for the dice in the future
     data class Other(override val emojiValue: String) : DiceEmoji()
@@ -32,6 +37,7 @@ sealed class DiceEmoji {
         fun fromString(emoji: String): DiceEmoji = when (emoji) {
             Dice.emojiValue -> Dice
             Dartboard.emojiValue -> Dartboard
+            Basketball.emojiValue -> Basketball
             else -> Other(emoji)
         }
     }

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/inlinequeryresults/InlineQueryResult.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/inlinequeryresults/InlineQueryResult.kt
@@ -5,10 +5,18 @@ import com.github.kotlintelegrambot.entities.ParseMode
 import com.google.gson.annotations.SerializedName
 
 enum class MimeType(val rawName: String) {
+    @SerializedName("text/html")
     TEXT_HTML("text/html"),
+    @SerializedName("video/mp4")
     VIDEO_MP4("video/mp4"),
+    @SerializedName("application/pdf")
     APPLICATION_PDF("application/pdf"),
-    APPLICATION_ZIP("application/zip")
+    @SerializedName("application/zip")
+    APPLICATION_ZIP("application/zip"),
+    @SerializedName("image/jpeg")
+    IMAGE_JPEG("image/jpeg"),
+    @SerializedName("image/gif")
+    IMAGE_GIF("image/gif")
 }
 
 fun String.toMimeType(): MimeType? =
@@ -70,6 +78,7 @@ sealed class InlineQueryResult(
         @SerializedName("gif_height") val gifHeight: Int? = null,
         @SerializedName("gif_duration") val gifDuration: Int? = null,
         @SerializedName("thumb_url") val thumbUrl: String,
+        @SerializedName("thumb_mime_type") val thumbMimeType: MimeType? = null,
         val title: String? = null,
         val caption: String? = null,
         @SerializedName("parse_mode") val parseMode: ParseMode? = null,
@@ -84,6 +93,7 @@ sealed class InlineQueryResult(
         @SerializedName("mpeg4_height") val mpeg4Height: Int? = null,
         @SerializedName("mpeg4_duration") val mpeg4Duration: Int? = null,
         @SerializedName("thumb_url") val thumbUrl: String,
+        @SerializedName("thumb_mime_type") val thumbMimeType: MimeType? = null,
         val title: String? = null,
         val caption: String? = null,
         @SerializedName("parse_mode") val parseMode: ParseMode? = null,

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendDiceIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendDiceIT.kt
@@ -46,6 +46,17 @@ class SendDiceIT : ApiClientIT() {
     }
 
     @Test
+    fun `sendDice with basketball emoji`() {
+        givenAnySendDiceResponse()
+
+        sut.sendDice(ANY_CHAT_ID, emoji = DiceEmoji.Basketball).execute()
+
+        val request = mockWebServer.takeRequest()
+        val expectedRequestBody = "chat_id=$ANY_CHAT_ID&emoji=🏀"
+        assertEquals(expectedRequestBody, request.body.readUtf8().decode())
+    }
+
+    @Test
     fun `sendDice with all the optional parameters`() {
         givenAnySendDiceResponse()
 


### PR DESCRIPTION
* Add 'via_bot' parameter to 'Message' model (#79)
* Support video thumbnails for inline GIF and MPEG4 animations (#79)
* Support the new basketball animation for the random dice (#79)