### PR TITLE
Catch exceptions in handlers

### DIFF
--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Dispatcher.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Dispatcher.kt
@@ -197,13 +197,23 @@ class Dispatcher(
         for (group in commandHandlers) {
             group.value
                 .filter { it.checkUpdate(update) }
-                .forEach { it.handlerCallback(bot, update) }
+                .forEach {
+                    try {
+                        it.handlerCallback(bot, update)
+                    } catch (exc: Exception) {
+                        exc.printStackTrace()
+                    }
+                }
         }
     }
 
     private fun handleError(error: TelegramError) {
         errorHandlers.forEach {
-            it(bot, error)
+            try {
+                it(bot, error)
+            } catch (exc: Exception) {
+                exc.printStackTrace()
+            }
         }
     }
 


### PR DESCRIPTION
For now any uncaught exception in an update or error handler kills the dispatching thread. This behaviour is unacceptable because a small mistake in one handler can make the bot unavailable for all users.

Moreover, though without dispatching thread the application actually stops serving, the process remains live and cannot be restarted by an external superviser.

This pull request adds try blocks into Dispatcher to catch errors from handlers and prevent killing of the thread.