### PR TITLE
Provide non nullable access to messages in command handlers #88

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ fun main(args: Array<String>) {
     val bot = bot {
         token = "YOUR_API_KEY"
         dispatch {
-            command("start") { bot, update->
-                val result = bot.sendMessage(chatId = update.message!!.chat.id, text = "Hi there!")
+            command("start") {
+                val result = bot.sendMessage(chatId = message.chat.id, text = "Hi there!")
                 result.fold({
                     // do something here with the response
                 },{

--- a/samples/dispatcher/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Main.kt
+++ b/samples/dispatcher/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Main.kt
@@ -38,7 +38,7 @@ fun main(args: Array<String>) {
                 bot.sendMessage(update.message!!.chat.id, text = "someone is replying or forwarding messages ...")
             }
 
-            command("start") { bot, update ->
+            command("start") {
 
                 val result = bot.sendMessage(chatId = update.message!!.chat.id, text = "Bot started")
 
@@ -49,7 +49,7 @@ fun main(args: Array<String>) {
                 })
             }
 
-            command("hello") { bot, update ->
+            command("hello") {
 
                 val result = bot.sendMessage(chatId = update.message!!.chat.id, text = "Hello, world!")
 
@@ -60,22 +60,22 @@ fun main(args: Array<String>) {
                 })
             }
 
-            command("commandWithArgs") { bot, update, args ->
+            command("commandWithArgs") {
                 val joinedArgs = args.joinToString()
-                val response = if (!joinedArgs.isNullOrBlank()) joinedArgs else "There is no text apart from command!"
-                bot.sendMessage(chatId = update.message!!.chat.id, text = response)
+                val response = if (joinedArgs.isNotBlank()) joinedArgs else "There is no text apart from command!"
+                bot.sendMessage(chatId = message.chat.id, text = response)
             }
 
-            command("markdown") { bot, update ->
+            command("markdown") {
                 val markdownText = "_Cool message_: *Markdown* is `beatiful` :P"
                 bot.sendMessage(
-                    chatId = update.message!!.chat.id,
+                    chatId = message.chat.id,
                     text = markdownText,
                     parseMode = MARKDOWN
                 )
             }
 
-            command("markdownV2") { bot, update ->
+            command("markdownV2") {
                 val markdownV2Text = """
                     *bold \*text*
                     _italic \*text_
@@ -92,38 +92,40 @@ fun main(args: Array<String>) {
                     ```
                 """.trimIndent()
                 bot.sendMessage(
-                    chatId = update.message!!.chat.id,
+                    chatId = message.chat.id,
                     text = markdownV2Text,
                     parseMode = MARKDOWN_V2
                 )
             }
 
-            command("inlineButtons") { bot, update ->
-                val chatId = update.message?.chat?.id ?: return@command
-
+            command("inlineButtons") {
                 val inlineKeyboardMarkup = InlineKeyboardMarkup(generateButtons())
-                bot.sendMessage(chatId = chatId, text = "Hello, inline buttons!", replyMarkup = inlineKeyboardMarkup)
+                bot.sendMessage(
+                    chatId = message.chat.id,
+                    text = "Hello, inline buttons!",
+                    replyMarkup = inlineKeyboardMarkup
+                )
             }
 
-            command("userButtons") { bot, update ->
-                val chatId = update.message?.chat?.id ?: return@command
-
+            command("userButtons") {
                 val keyboardMarkup = KeyboardReplyMarkup(keyboard = generateUsersButton(), resizeKeyboard = true)
-                bot.sendMessage(chatId = chatId, text = "Hello, users buttons!", replyMarkup = keyboardMarkup)
+                bot.sendMessage(
+                    chatId = message.chat.id,
+                    text = "Hello, users buttons!",
+                    replyMarkup = keyboardMarkup
+                )
             }
 
-            command("mediaGroup") { bot, update ->
-                val chatId = update.message?.chat?.id ?: return@command
-                val messageId = update.message?.messageId ?: return@command
+            command("mediaGroup") {
                 bot.sendMediaGroup(
-                    chatId = chatId,
+                    chatId = message.chat.id,
                     mediaGroup = MediaGroup.from(
                         InputMediaPhoto(
                             media = ByUrl("https://www.sngular.com/wp-content/uploads/2019/11/Kotlin-Blog-1400x411.png"),
                             caption = "I come from an url :P"
                         )
                     ),
-                    replyToMessageId = messageId
+                    replyToMessageId = message.messageId
                 )
             }
 
@@ -191,9 +193,8 @@ fun main(args: Array<String>) {
                 )
             }
 
-            command("diceAsDartboard") { bot, update ->
-                val chatId = update.message?.chat?.id ?: return@command
-                bot.sendDice(chatId, DiceEmoji.Dartboard)
+            command("diceAsDartboard") {
+                bot.sendDice(message.chat.id, DiceEmoji.Dartboard)
             }
 
             dice { bot, message, dice ->

--- a/samples/polls/src/main/kotlin/com/github/kotlintelegrambot/polls/Main.kt
+++ b/samples/polls/src/main/kotlin/com/github/kotlintelegrambot/polls/Main.kt
@@ -13,20 +13,18 @@ fun main() {
             pollAnswer { _, pollAnswer ->
                 println("${pollAnswer.user.username} has selected the option ${pollAnswer.optionIds.lastOrNull()} in the poll ${pollAnswer.pollId}")
             }
-            command("regularPoll") { bot, update, _ ->
-                val chatId = update.message?.chat?.id ?: return@command
+            command("regularPoll") {
                 bot.sendPoll(
-                    chatId = chatId,
+                    chatId = message.chat.id,
                     question = "Pizza with or without pineapple?",
                     options = listOf("With :(", "Without :)"),
                     isAnonymous = false
                 )
             }
 
-            command("quizPoll") { bot, update, _ ->
-                val chatId = update.message?.chat?.id ?: return@command
+            command("quizPoll") {
                 bot.sendPoll(
-                    chatId = chatId,
+                    chatId = message.chat.id,
                     type = QUIZ,
                     question = "Java or Kotlin?",
                     options = listOf("Java", "Kotlin"),
@@ -35,10 +33,9 @@ fun main() {
                 )
             }
 
-            command("closedPoll") { bot, update, _ ->
-                val chatId = update.message?.chat?.id ?: return@command
+            command("closedPoll") {
                 bot.sendPoll(
-                    chatId = chatId,
+                    chatId = message.chat.id,
                     type = QUIZ,
                     question = "Foo or Bar?",
                     options = listOf("Foo", "Bar", "FooBar"),

--- a/samples/webhook/src/main/kotlin/com/github/kotlintelegrambot/webhook/Main.kt
+++ b/samples/webhook/src/main/kotlin/com/github/kotlintelegrambot/webhook/Main.kt
@@ -35,9 +35,8 @@ fun main() {
             allowedUpdates = listOf("message")
         }
         dispatch {
-            command("hello") { _, update, _ ->
-                val chatId = update.message?.chat?.id ?: return@command
-                bot.sendMessage(chatId, "Hey bruh!")
+            command("hello") {
+                bot.sendMessage(message.chat.id, "Hey bruh!")
             }
         }
     }

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Dispatcher.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Dispatcher.kt
@@ -1,7 +1,6 @@
 package com.github.kotlintelegrambot.dispatcher
 
 import com.github.kotlintelegrambot.Bot
-import com.github.kotlintelegrambot.CommandHandleUpdate
 import com.github.kotlintelegrambot.ContactHandleUpdate
 import com.github.kotlintelegrambot.HandleAnimationUpdate
 import com.github.kotlintelegrambot.HandleAudioUpdate
@@ -23,6 +22,7 @@ import com.github.kotlintelegrambot.dispatcher.handlers.CallbackQueryHandler
 import com.github.kotlintelegrambot.dispatcher.handlers.ChannelHandler
 import com.github.kotlintelegrambot.dispatcher.handlers.CheckoutHandler
 import com.github.kotlintelegrambot.dispatcher.handlers.CommandHandler
+import com.github.kotlintelegrambot.dispatcher.handlers.CommandHandlerEnvironment
 import com.github.kotlintelegrambot.dispatcher.handlers.ContactHandler
 import com.github.kotlintelegrambot.dispatcher.handlers.DiceHandler
 import com.github.kotlintelegrambot.dispatcher.handlers.Handler
@@ -52,11 +52,7 @@ fun Dispatcher.message(filter: Filter, handleUpdate: HandleUpdate) {
     addHandler(MessageHandler(handleUpdate, filter))
 }
 
-fun Dispatcher.command(command: String, body: HandleUpdate) {
-    addHandler(CommandHandler(command, body))
-}
-
-fun Dispatcher.command(command: String, body: CommandHandleUpdate) {
+fun Dispatcher.command(command: String, body: CommandHandlerEnvironment.() -> Unit) {
     addHandler(CommandHandler(command, body))
 }
 

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/CommandHandlerTest.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/CommandHandlerTest.kt
@@ -1,0 +1,72 @@
+package com.github.kotlintelegrambot.dispatcher.handlers
+
+import anyMessage
+import anyUpdate
+import com.github.kotlintelegrambot.Bot
+import io.mockk.mockk
+import io.mockk.verify
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import org.junit.jupiter.api.Test
+
+class CommandHandlerTest {
+
+    private val handlerFunctionMock = mockk<CommandHandlerEnvironment.() -> Unit>(relaxed = true)
+
+    private val sut = CommandHandler(ANY_COMMAND_NAME, handlerFunctionMock)
+
+    @Test
+    fun `checkUpdate returns true for the given command`() {
+        val anyCommand = anyUpdate(message = anyMessage(text = "/$ANY_COMMAND_NAME"))
+
+        val checkUpdateResult = sut.checkUpdate(anyCommand)
+
+        assertTrue(checkUpdateResult)
+    }
+
+    @Test
+    fun `checkUpdate returns true for the given command with arguments`() {
+        val anyCommandWithArguments = anyUpdate(
+            message = anyMessage(text = "/$ANY_COMMAND_NAME a b")
+        )
+
+        val checkUpdateResult = sut.checkUpdate(anyCommandWithArguments)
+
+        assertTrue(checkUpdateResult)
+    }
+
+    @Test
+    fun `checkUpdate returns false for another command`() {
+        val anyOtherCommand = anyUpdate(message = anyMessage(text = "/fake"))
+
+        val checkUpdateResult = sut.checkUpdate(anyOtherCommand)
+
+        assertFalse(checkUpdateResult)
+    }
+
+    @Test
+    fun `checkUpdate returns false for a non command`() {
+        val anyNonCommandUpdate = anyUpdate(message = anyMessage(text = "non command text"))
+
+        val checkUpdateResult = sut.checkUpdate(anyNonCommandUpdate)
+
+        assertFalse(checkUpdateResult)
+    }
+
+    @Test
+    fun `command update is properly dispatched to the handler function`() {
+        val botMock = mockk<Bot>()
+        val commandMessage = anyMessage(text = "/$ANY_COMMAND_NAME $ANY_ARG")
+        val anyUpdate = anyUpdate(message = commandMessage)
+
+        sut.handlerCallback(botMock, anyUpdate)
+
+        val expectedArgs = CommandHandlerEnvironment(botMock, anyUpdate, commandMessage, listOf(ANY_ARG))
+        verify { handlerFunctionMock.invoke(expectedArgs) }
+    }
+
+    private companion object {
+        const val ANY_COMMAND_NAME = "test"
+        const val ANY_ARG = "arggggg"
+    }
+}


### PR DESCRIPTION
* The old command handlers have been removed and a new one has been added. The new one, along with the `command` function in `Dispatcher`, allows direct access to `bot`, `update`, `message` and `args` in the scope of the function provided to `command` instead of them being provided as arguments of the function.

* All the examples using the old `command` functions have been updated.

* Doc updated to reflect the new API.

* Tests have been added for the `CommandHandler` class.


I'm not sure if this change worths it... 

To add it, it's needed to remove all the previous `command` functions because otherwise there is resolution ambiguity between them. 

Other option would be to add the new function with a different name than `command` and in that way we'd avoid the resolution ambiguity, however I haven't been able to get a name good enough for it.

Also, an option I explored was to add a new `command` function providing the four arguments in the same way the old ones work but I don't really like it because it'll be always needed to indicate all the arguments in the function, even when they are not used.

I'd appreciate you feedback/thoughts here @seik 