### PR TITLE
Improve library logging #82

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ dependencies {
 1. [Getting updates](https://github.com/kotlin-telegram-bot/kotlin-telegram-bot/tree/master/docs/gettingUpdates.md)
 2. [Polls](https://github.com/kotlin-telegram-bot/kotlin-telegram-bot/tree/master/docs/polls.md)
 3. [Dice](https://github.com/kotlin-telegram-bot/kotlin-telegram-bot/tree/master/docs/dice.md)
+4. [Logging](https://github.com/kotlin-telegram-bot/kotlin-telegram-bot/tree/master/docs/logging.md)
 
 ## Contributing
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,25 @@
+# Logging
+
+The library provides the possibility of configuring the logging in order to allow logging certain parts of the work performed by the library.
+
+Nowadays, there are only two things that can be logged from the library side: the network requests and responses performed by the library, and the uncaught exceptions that are thrown from the handlers.
+
+In order to configure the logging level you want, you have to set the `logLevel` property when building your bot instance. If you don't set it, it will default to not logging anything. You can do it in the next way: 
+
+````kotlin
+bot {
+    logLevel = LogLevel.All()
+}
+````
+
+
+The different available log levels, and the meaning of every one are shown below:
+
+* `LogLevel.None` No logs.
+* `LogLevel.All` Logs network requests, network responses and uncaught exceptions thrown in handlers execution. The log level for the network information can be also configured through the `networkLogLevel` property available in the `All` class (it'll default to `LogLevel.Network.Body`).  
+* `LogLevel.Network` Logs network requests and responses. It has different levels.
+  * `LogLevel.Network.None` No logs.
+  * `LogLevel.Network.Basic` Logs requests and responses lines.
+  * `LogLevel.Network.Headers` Logs requests and responses lines and their respective headers.
+  * `LogLevel.Network.Body` Logs requests and responses lines and their respective headers and bodies (if present).
+* `LogLevel.Error` Logs uncaught exceptions thrown in the handlers execution

--- a/samples/dispatcher/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Main.kt
+++ b/samples/dispatcher/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Main.kt
@@ -18,8 +18,8 @@ import com.github.kotlintelegrambot.entities.inputmedia.MediaGroup
 import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton
 import com.github.kotlintelegrambot.entities.keyboard.KeyboardButton
 import com.github.kotlintelegrambot.extensions.filters.Filter
+import com.github.kotlintelegrambot.logging.LogLevel
 import com.github.kotlintelegrambot.network.fold
-import okhttp3.logging.HttpLoggingInterceptor
 
 fun main(args: Array<String>) {
 
@@ -27,7 +27,7 @@ fun main(args: Array<String>) {
 
         token = "YOUR_API_KEY"
         timeout = 30
-        logLevel = HttpLoggingInterceptor.Level.BODY
+        logLevel = LogLevel.Network.Body
 
         dispatch {
             message(Filter.Sticker) { bot, update ->

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -19,6 +19,7 @@ import com.github.kotlintelegrambot.entities.polls.PollType
 import com.github.kotlintelegrambot.entities.stickers.MaskPosition
 import com.github.kotlintelegrambot.errors.RetrieveUpdatesError
 import com.github.kotlintelegrambot.errors.TelegramError
+import com.github.kotlintelegrambot.logging.LogLevel
 import com.github.kotlintelegrambot.network.ApiClient
 import com.github.kotlintelegrambot.network.bimap
 import com.github.kotlintelegrambot.network.call
@@ -29,7 +30,6 @@ import com.github.kotlintelegrambot.webhook.WebhookConfigBuilder
 import java.io.File as SystemFile
 import java.net.Proxy
 import java.util.Date
-import okhttp3.logging.HttpLoggingInterceptor
 
 fun bot(body: Bot.Builder.() -> Unit): Bot = Bot.Builder().build(body)
 
@@ -50,7 +50,7 @@ class Bot private constructor(
     token: String,
     apiUrl: String,
     timeout: Int = 30,
-    logLevel: HttpLoggingInterceptor.Level = HttpLoggingInterceptor.Level.BODY,
+    logLevel: LogLevel,
     proxy: Proxy
 ) {
     private val apiClient: ApiClient = ApiClient(token, apiUrl, timeout, logLevel, proxy)
@@ -58,6 +58,7 @@ class Bot private constructor(
     init {
         updater.bot = this
         updater.dispatcher.bot = this
+        updater.dispatcher.logLevel = logLevel
     }
 
     class Builder {
@@ -67,7 +68,7 @@ class Bot private constructor(
         lateinit var token: String
         var timeout: Int = 30
         var apiUrl: String = "https://api.telegram.org/"
-        var logLevel: HttpLoggingInterceptor.Level = HttpLoggingInterceptor.Level.NONE
+        var logLevel: LogLevel = LogLevel.None
         var proxy: Proxy = Proxy.NO_PROXY
 
         fun build(): Bot {

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Dispatcher.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Dispatcher.kt
@@ -44,6 +44,7 @@ import com.github.kotlintelegrambot.dispatcher.handlers.media.VoiceHandler
 import com.github.kotlintelegrambot.entities.Update
 import com.github.kotlintelegrambot.errors.TelegramError
 import com.github.kotlintelegrambot.extensions.filters.Filter
+import com.github.kotlintelegrambot.logging.LogLevel
 import com.github.kotlintelegrambot.types.DispatchableObject
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
@@ -149,9 +150,9 @@ fun Dispatcher.dice(body: HandleDice) {
 }
 
 class Dispatcher(
-    val updatesQueue: BlockingQueue<DispatchableObject> = LinkedBlockingQueue<DispatchableObject>()
+    val updatesQueue: BlockingQueue<DispatchableObject> = LinkedBlockingQueue()
 ) {
-
+    internal lateinit var logLevel: LogLevel
     lateinit var bot: Bot
 
     private val commandHandlers = mutableMapOf<String, ArrayList<Handler>>()
@@ -205,7 +206,9 @@ class Dispatcher(
                     try {
                         it.handlerCallback(bot, update)
                     } catch (exc: Exception) {
-                        exc.printStackTrace()
+                        if (logLevel.shouldLogErrors()) {
+                            exc.printStackTrace()
+                        }
                     }
                 }
         }
@@ -216,7 +219,9 @@ class Dispatcher(
             try {
                 it(bot, error)
             } catch (exc: Exception) {
-                exc.printStackTrace()
+                if (logLevel.shouldLogErrors()) {
+                    exc.printStackTrace()
+                }
             }
         }
     }

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/logging/LogLevel.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/logging/LogLevel.kt
@@ -1,0 +1,90 @@
+package com.github.kotlintelegrambot.logging
+
+import com.github.kotlintelegrambot.logging.LogLevel.All
+import com.github.kotlintelegrambot.logging.LogLevel.Error
+import com.github.kotlintelegrambot.logging.LogLevel.Network
+import com.github.kotlintelegrambot.logging.LogLevel.Network.Basic
+import com.github.kotlintelegrambot.logging.LogLevel.Network.Body
+import com.github.kotlintelegrambot.logging.LogLevel.Network.Headers
+import com.github.kotlintelegrambot.logging.LogLevel.None
+import okhttp3.logging.HttpLoggingInterceptor
+
+sealed class LogLevel {
+    /** No logs **/
+    object None : LogLevel()
+
+    /** Logs network requests, network responses and uncaught exceptions
+     * thrown in handlers execution **/
+    data class All(
+        val networkLogLevel: LogLevel.Network = Body
+    ) : LogLevel()
+
+    /** Logs network requests and responses information **/
+    sealed class Network : LogLevel() {
+        /** No logs **/
+        object None : Network()
+        /**
+         * Logs requests and responses lines.
+         *
+         * Example:
+         * --> POST /test http/1.1 (8-byte body)
+         * <-- 200 OK (29ms, 4-byte body)
+         */
+        object Basic : Network()
+        /**
+         * Logs requests and responses lines and their respective headers.
+         *
+         * Example:
+         * --> POST /greeting http/1.1
+         * Host: example.com
+         * Content-Type: plain/text
+         * Content-Length: 3
+         * --> END POST
+         *
+         * <-- 200 OK (22ms)
+         * Content-Type: plain/text
+         * Content-Length: 6
+         * <-- END HTTP
+         */
+        object Headers : Network()
+        /**
+         * Logs requests and responses lines and their respective headers and bodies (if present).
+         *
+         * Example:
+         * --> POST /greeting http/1.1
+         * Host: example.com
+         * Content-Type: plain/text
+         * Content-Length: 3
+         *
+         * Hi?
+         * --> END POST
+         *
+         * <-- 200 OK (22ms)
+         * Content-Type: plain/text
+         * Content-Length: 6
+         *
+         * Hello!
+         * <-- END HTTP
+         */
+        object Body : Network()
+    }
+
+    /** Logs uncaught exceptions thrown in the handlers execution **/
+    object Error : LogLevel()
+
+    internal fun shouldLogErrors(): Boolean = this is All || this is Error
+}
+
+internal fun LogLevel.toOkHttpLogLevel(): HttpLoggingInterceptor.Level = when (this) {
+    None -> HttpLoggingInterceptor.Level.NONE
+    is All -> networkLogLevel.toOkHttpLogLevel()
+    is Network -> toOkHttpLogLevel()
+    Error -> HttpLoggingInterceptor.Level.NONE
+}
+
+private fun Network.toOkHttpLogLevel(): HttpLoggingInterceptor.Level = when (this) {
+    Network.None -> HttpLoggingInterceptor.Level.NONE
+    Basic -> HttpLoggingInterceptor.Level.BASIC
+    Headers -> HttpLoggingInterceptor.Level.HEADERS
+    Body -> HttpLoggingInterceptor.Level.BODY
+}

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -28,6 +28,8 @@ import com.github.kotlintelegrambot.entities.polls.Poll
 import com.github.kotlintelegrambot.entities.polls.PollType
 import com.github.kotlintelegrambot.entities.stickers.MaskPosition
 import com.github.kotlintelegrambot.entities.stickers.StickerSet
+import com.github.kotlintelegrambot.logging.LogLevel
+import com.github.kotlintelegrambot.logging.toOkHttpLogLevel
 import com.github.kotlintelegrambot.network.multipart.MultipartBodyFactory
 import com.github.kotlintelegrambot.network.multipart.toMultipartBodyPart
 import com.github.kotlintelegrambot.network.retrofit.converters.DiceEmojiConverterFactory
@@ -93,7 +95,7 @@ class ApiClient(
     private val token: String,
     private val apiUrl: String,
     private val botTimeout: Int = 30,
-    logLevel: HttpLoggingInterceptor.Level = HttpLoggingInterceptor.Level.NONE,
+    logLevel: LogLevel,
     proxy: Proxy = Proxy.NO_PROXY,
     private val gson: Gson = GsonFactory.createForApiClient(),
     private val multipartBodyFactory: MultipartBodyFactory = MultipartBodyFactory(GsonFactory.createForMultipartBodyFactory())
@@ -103,7 +105,7 @@ class ApiClient(
 
     // TODO check if init is the best approach for this
     init {
-        val logging = HttpLoggingInterceptor().apply { level = logLevel }
+        val logging = HttpLoggingInterceptor().apply { level = logLevel.toOkHttpLogLevel() }
 
         val httpClient = OkHttpClient.Builder()
             .connectTimeout(botTimeout + 10L, TimeUnit.SECONDS)

--- a/telegram/src/test/kotlin/DispatcherTest.kt
+++ b/telegram/src/test/kotlin/DispatcherTest.kt
@@ -2,6 +2,7 @@ import com.github.kotlintelegrambot.Bot
 import com.github.kotlintelegrambot.HandleUpdate
 import com.github.kotlintelegrambot.dispatcher.Dispatcher
 import com.github.kotlintelegrambot.dispatcher.handlers.Handler
+import com.github.kotlintelegrambot.logging.LogLevel
 import com.github.kotlintelegrambot.types.DispatchableObject
 import io.mockk.every
 import io.mockk.mockk
@@ -14,8 +15,9 @@ class DispatcherTest {
     private val botMock = mockk<Bot>()
     private val blockingQueueMock = mockk<BlockingQueue<DispatchableObject>>()
 
-    private val sut = Dispatcher(updatesQueue = blockingQueueMock).apply {
+    private val sut = Dispatcher(blockingQueueMock).apply {
         bot = botMock
+        logLevel = LogLevel.None
     }
 
     @Test

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/logging/LogLevelTest.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/logging/LogLevelTest.kt
@@ -1,0 +1,36 @@
+package com.github.kotlintelegrambot.logging
+
+import junit.framework.TestCase.assertEquals
+import okhttp3.logging.HttpLoggingInterceptor
+import org.junit.jupiter.api.Test
+
+class LogLevelTest {
+
+    @Test
+    fun `log level is properly mapped to ok http's log level`() {
+        assertEquals(HttpLoggingInterceptor.Level.NONE, LogLevel.None.toOkHttpLogLevel())
+        assertEquals(HttpLoggingInterceptor.Level.NONE, LogLevel.Error.toOkHttpLogLevel())
+        assertEquals(HttpLoggingInterceptor.Level.NONE, LogLevel.All(LogLevel.Network.None).toOkHttpLogLevel())
+        assertEquals(HttpLoggingInterceptor.Level.NONE, LogLevel.Network.None.toOkHttpLogLevel())
+        assertEquals(HttpLoggingInterceptor.Level.BASIC, LogLevel.All(LogLevel.Network.Basic).toOkHttpLogLevel())
+        assertEquals(HttpLoggingInterceptor.Level.BASIC, LogLevel.Network.Basic.toOkHttpLogLevel())
+        assertEquals(HttpLoggingInterceptor.Level.HEADERS, LogLevel.All(LogLevel.Network.Headers).toOkHttpLogLevel())
+        assertEquals(HttpLoggingInterceptor.Level.HEADERS, LogLevel.Network.Headers.toOkHttpLogLevel())
+        assertEquals(HttpLoggingInterceptor.Level.BODY, LogLevel.All(LogLevel.Network.Body).toOkHttpLogLevel())
+        assertEquals(HttpLoggingInterceptor.Level.BODY, LogLevel.Network.Body.toOkHttpLogLevel())
+    }
+
+    @Test
+    fun `should only log errors with All and Error`() {
+        assertEquals(false, LogLevel.None.shouldLogErrors())
+        assertEquals(true, LogLevel.Error.shouldLogErrors())
+        assertEquals(true, LogLevel.All(LogLevel.Network.None).shouldLogErrors())
+        assertEquals(false, LogLevel.Network.None.shouldLogErrors())
+        assertEquals(true, LogLevel.All(LogLevel.Network.Basic).shouldLogErrors())
+        assertEquals(false, LogLevel.Network.Basic.shouldLogErrors())
+        assertEquals(true, LogLevel.All(LogLevel.Network.Headers).shouldLogErrors())
+        assertEquals(false, LogLevel.Network.Headers.shouldLogErrors())
+        assertEquals(true, LogLevel.All(LogLevel.Network.Body).shouldLogErrors())
+        assertEquals(false, LogLevel.Network.Body.shouldLogErrors())
+    }
+}

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/ApiClientIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/ApiClientIT.kt
@@ -1,5 +1,6 @@
 package com.github.kotlintelegrambot.network.apiclient
 
+import com.github.kotlintelegrambot.logging.LogLevel
 import com.github.kotlintelegrambot.network.ApiClient
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
@@ -15,7 +16,7 @@ abstract class ApiClientIT {
     fun setUp() {
         mockWebServer.start()
         val webServerUrl = mockWebServer.url("")
-        sut = ApiClient(token = "", apiUrl = webServerUrl.toString())
+        sut = ApiClient(token = "", apiUrl = webServerUrl.toString(), logLevel = LogLevel.None)
     }
 
     @AfterEach


### PR DESCRIPTION
* A new class called 'LogLevel' has been created to represent the different logging configurations provided by the library. This new class has replaced the previous log level type which was the one provided by ok http.

* Doc regarding logging has been added.

* Now it's possible to enable/disable the logging of the uncaught exceptions thrown by the handlers