### PR TITLE
Add missing CachedPhoto in InlineQueryResult

### DIFF
--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/inlinequeryresults/InlineQueryResult.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/inlinequeryresults/InlineQueryResult.kt
@@ -242,9 +242,20 @@ sealed class InlineQueryResult(
         @SerializedName("input_message_content") val inputMessageContent: InputMessageContent? = null
     ) : InlineQueryResult(QueryResultTypes.MPEG4_GIF)
 
+    data class CachedPhoto(
+        override val id: String,
+        @SerializedName("photo_file_id") val photoFileId: String,
+        val title: String? = null,
+        val description: String? = null,
+        val caption: String? = null,
+        @SerializedName("parse_mode") val parseMode: ParseMode? = null,
+        @SerializedName("reply_markup") override val replyMarkup: InlineKeyboardMarkup? = null,
+        @SerializedName("input_message_content") val inputMessageContent: InputMessageContent? = null
+    ) : InlineQueryResult(QueryResultTypes.PHOTO)
+
     data class CachedSticker(
         override val id: String,
-        @SerializedName("sticket_file_id") val stickerFileId: String,
+        @SerializedName("sticker_file_id") val stickerFileId: String,
         @SerializedName("reply_markup") override val replyMarkup: InlineKeyboardMarkup? = null,
         @SerializedName("input_message_content") val inputMessageContent: InputMessageContent? = null
     ) : InlineQueryResult(QueryResultTypes.STICKER)
@@ -252,6 +263,7 @@ sealed class InlineQueryResult(
     data class CachedVideo(
         override val id: String,
         @SerializedName("video_file_id") val videoFileId: String,
+        val title: String,
         val description: String? = null,
         val caption: String? = null,
         @SerializedName("parse_mode") val parseMode: ParseMode? = null,
@@ -264,7 +276,7 @@ sealed class InlineQueryResult(
         @SerializedName("voice_file_id") val voiceFileId: String,
         val title: String,
         val caption: String? = null,
-        @SerializedName("parse_mode") val parseModel: ParseMode? = null,
+        @SerializedName("parse_mode") val parseMode: ParseMode? = null,
         @SerializedName("reply_markup") override val replyMarkup: InlineKeyboardMarkup? = null,
         @SerializedName("input_message_content") val inputMessageContent: InputMessageContent? = null
     ) : InlineQueryResult(QueryResultTypes.VOICE)

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/inlinequeryresults/InputMessageContent.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/inlinequeryresults/InputMessageContent.kt
@@ -22,7 +22,7 @@ sealed class InputMessageContent {
         val title: String,
         val address: String,
         @SerializedName("foursquare_id") val foursquareId: String? = null,
-        @SerializedName("foursquare_type") val foursqeareType: String? = null
+        @SerializedName("foursquare_type") val foursquareType: String? = null
     ) : InputMessageContent()
 
     data class Contact(

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/serialization/adapter/InlineQueryResultAdapter.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/serialization/adapter/InlineQueryResultAdapter.kt
@@ -7,6 +7,7 @@ import com.github.kotlintelegrambot.entities.inlinequeryresults.InlineQueryResul
 import com.github.kotlintelegrambot.entities.inlinequeryresults.InlineQueryResult.CachedDocument
 import com.github.kotlintelegrambot.entities.inlinequeryresults.InlineQueryResult.CachedGif
 import com.github.kotlintelegrambot.entities.inlinequeryresults.InlineQueryResult.CachedMpeg4Gif
+import com.github.kotlintelegrambot.entities.inlinequeryresults.InlineQueryResult.CachedPhoto
 import com.github.kotlintelegrambot.entities.inlinequeryresults.InlineQueryResult.CachedSticker
 import com.github.kotlintelegrambot.entities.inlinequeryresults.InlineQueryResult.CachedVideo
 import com.github.kotlintelegrambot.entities.inlinequeryresults.InlineQueryResult.CachedVoice
@@ -48,6 +49,7 @@ class InlineQueryResultAdapter : JsonSerializer<InlineQueryResult> {
         is CachedDocument -> context.serialize(src, CachedDocument::class.java)
         is CachedGif -> context.serialize(src, CachedGif::class.java)
         is CachedMpeg4Gif -> context.serialize(src, CachedMpeg4Gif::class.java)
+        is CachedPhoto -> context.serialize(src, CachedPhoto::class.java)
         is CachedSticker -> context.serialize(src, CachedSticker::class.java)
         is CachedVideo -> context.serialize(src, CachedVideo::class.java)
         is CachedVoice -> context.serialize(src, CachedVoice::class.java)


### PR DESCRIPTION
I've noticed that [InlineQueryResultCachedPhoto](https://core.telegram.org/bots/api#inlinequeryresultcachedphoto) is missing. In addition, I fixed some typos.