### PR TITLE
Fix getStickerSet method

### DIFF
--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/stickers/StickerSet.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/stickers/StickerSet.kt
@@ -1,5 +1,6 @@
 package com.github.kotlintelegrambot.entities.stickers
 
+import com.github.kotlintelegrambot.entities.files.PhotoSize
 import com.google.gson.annotations.SerializedName as Name
 
 data class StickerSet(
@@ -7,5 +8,6 @@ data class StickerSet(
     val title: String,
     @Name("is_animated") val isAnimated: Boolean,
     @Name("contains_masks") val containsMasks: Boolean,
-    @Name("stickers") val stickers: List<Sticker>
+    @Name("stickers") val stickers: List<Sticker>,
+    val thumb: PhotoSize?
 )

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
@@ -653,7 +653,7 @@ interface ApiService {
 
     @GET("getStickerSet")
     fun getStickerSet(
-        @Field("name") name: String
+        @Query("name") name: String
     ): Call<Response<StickerSet>>
 
     @Multipart


### PR DESCRIPTION
`getStickerSet`  fails with an exception:
```
java.lang.IllegalArgumentException: @Field parameters can only be used with form encoding. (parameter #1)
    for method ApiService.getStickerSet
```
and the result doesn't contain `thumb` field (from API 4.7, see #63).  This pull request fixes it.
