### PR TITLE
Fix sendChatAction method

### DIFF
--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/ChatAction.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/ChatAction.kt
@@ -1,14 +1,16 @@
 package com.github.kotlintelegrambot.entities
 
-enum class ChatAction(val apiName: String) {
-    TYPING("typing"),
-    UPLOAD_PHOTO("upload_photo"),
-    RECORD_VIDEO("record_video"),
-    UPLOAD_VIDEO("upload_video"),
-    RECORD_AUDIO("record_audio"),
-    UPLOAD_AUDIO("upload_audio"),
-    UPLOAD_DOCUMENT("upload_document"),
-    FIND_LOCATION("find_location");
+import com.google.gson.annotations.SerializedName
 
-    override fun toString() = apiName
+enum class ChatAction {
+    @SerializedName("typing") TYPING,
+    @SerializedName("upload_photo") UPLOAD_PHOTO,
+    @SerializedName("record_video") RECORD_VIDEO,
+    @SerializedName("upload_video") UPLOAD_VIDEO,
+    @SerializedName("record_audio") RECORD_AUDIO,
+    @SerializedName("upload_audio") UPLOAD_AUDIO,
+    @SerializedName("upload_document") UPLOAD_DOCUMENT,
+    @SerializedName("find_location") FIND_LOCATION,
+    @SerializedName("record_video_note") RECORD_VIDEO_NOTE,
+    @SerializedName("upload_video_note") UPLOAD_VIDEO_NOTE;
 }


### PR DESCRIPTION
 - Fixed: `sendChatAction` fails with `java.lang.IllegalStateException` on serializing `ChatAction`
 - Added missing `record_video_note` and `upload_video_note` actions. See https://core.telegram.org/bots/api#sendchataction
 - Removed `apiName` field. Inspired by a comment in the similar ParseMode enum class: https://github.com/kotlin-telegram-bot/kotlin-telegram-bot/blob/be82c37b165b8044bf5ecaab43a8ef4a0d6bfe10/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/ParseMode.kt#L5