### PR TITLE
Changing String to ParseMode

### DIFF
--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -191,7 +191,7 @@ class Bot private constructor(
     ) = apiClient.sendMessage(
         chatId,
         text,
-        parseMode?.modeName,
+        parseMode,
         disableWebPagePreview,
         disableNotification,
         replyToMessageId,
@@ -240,7 +240,7 @@ class Bot private constructor(
         chatId,
         photo,
         caption,
-        parseMode?.modeName,
+        parseMode,
         disableNotification,
         replyToMessageId,
         replyMarkup
@@ -354,7 +354,7 @@ class Bot private constructor(
         chatId,
         fileId,
         caption,
-        parseMode?.modeName,
+        parseMode,
         disableNotification,
         replyToMessageId,
         replyMarkup
@@ -435,7 +435,7 @@ class Bot private constructor(
         width: Int? = null,
         height: Int? = null,
         caption: String? = null,
-        parseMode: String? = null,
+        parseMode: ParseMode? = null,
         disableNotification: Boolean? = null,
         replyToMessageId: Long? = null,
         replyMarkup: ReplyMarkup? = null
@@ -837,7 +837,7 @@ class Bot private constructor(
         messageId,
         inlineMessageId,
         text,
-        parseMode?.modeName,
+        parseMode,
         disableWebPagePreview,
         replyMarkup
     ).call()

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -187,7 +187,7 @@ class ApiClient(
     fun sendMessage(
         chatId: Long,
         text: String,
-        parseMode: String?,
+        parseMode: ParseMode?,
         disableWebPagePreview: Boolean?,
         disableNotification: Boolean?,
         replyToMessageId: Long?,
@@ -235,7 +235,7 @@ class ApiClient(
         chatId: Long,
         photo: String,
         caption: String?,
-        parseMode: String?,
+        parseMode: ParseMode?,
         disableNotification: Boolean?,
         replyToMessageId: Long?,
         replyMarkup: ReplyMarkup?
@@ -323,7 +323,7 @@ class ApiClient(
         chatId: Long,
         fileId: String,
         caption: String?,
-        parseMode: String?,
+        parseMode: ParseMode?,
         disableNotification: Boolean?,
         replyToMessageId: Long?,
         replyMarkup: ReplyMarkup?
@@ -446,7 +446,7 @@ class ApiClient(
         width: Int?,
         height: Int?,
         caption: String?,
-        parseMode: String?,
+        parseMode: ParseMode?,
         disableNotification: Boolean?,
         replyToMessageId: Long?,
         replyMarkup: ReplyMarkup?
@@ -964,7 +964,7 @@ class ApiClient(
         messageId: Long?,
         inlineMessageId: String?,
         text: String,
-        parseMode: String?,
+        parseMode: ParseMode?,
         disableWebPagePreview: Boolean?,
         replyMarkup: ReplyMarkup?
     ): Call<Response<Message>> {

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
@@ -103,7 +103,7 @@ interface ApiService {
     fun sendMessage(
         @Field("chat_id") chatId: Long,
         @Field("text") text: String,
-        @Field("parse_mode") parseMode: String?,
+        @Field("parse_mode") parseMode: ParseMode?,
         @Field("disable_web_page_preview") disableWebPagePreview: Boolean?,
         @Field("disable_notification") disableNotification: Boolean?,
         @Field("reply_to_message_id") replyToMessageId: Long?,
@@ -137,7 +137,7 @@ interface ApiService {
         @Field("chat_id") chatId: Long,
         @Field("photo") fileId: String,
         @Field("caption") caption: String?,
-        @Field("parse_mode") parseMode: String?,
+        @Field("parse_mode") parseMode: ParseMode?,
         @Field("disable_notification") disableNotification: Boolean?,
         @Field("reply_to_message_id") replyToMessageId: Long?,
         @Field("reply_markup") replyMarkup: ReplyMarkup? = null
@@ -187,7 +187,7 @@ interface ApiService {
         @Field("chat_id") chatId: Long,
         @Field("document") fileId: String,
         @Field("caption") caption: String?,
-        @Field("parse_mode") parseMode: String?,
+        @Field("parse_mode") parseMode: ParseMode?,
         @Field("disable_notification") disableNotification: Boolean?,
         @Field("reply_to_message_id") replyToMessageId: Long?,
         @Field("reply_markup") replyMarkup: ReplyMarkup? = null
@@ -245,7 +245,7 @@ interface ApiService {
         @Field("width") width: Int?,
         @Field("height") height: Int?,
         @Field("caption") caption: String?,
-        @Field("parse_mode") parseMode: String?,
+        @Field("parse_mode") parseMode: ParseMode?,
         @Field("disable_notification") disableNotification: Boolean?,
         @Field("reply_to_message_id") replyToMessageId: Long?,
         @Field("reply_markup") replyMarkup: ReplyMarkup? = null
@@ -578,7 +578,7 @@ interface ApiService {
         @Field("message_id") messageId: Long?,
         @Field("inline_message_id") inlineMessageId: String?,
         @Field("text") text: String,
-        @Field("parse_mode") parseMode: String?,
+        @Field("parse_mode") parseMode: ParseMode?,
         @Field("disable_web_page_preview") disableWebPagePreview: Boolean?,
         @Field("reply_markup") replyMarkup: ReplyMarkup? = null
     ): Call<Response<Message>>


### PR DESCRIPTION
@seik 

Fix #73 
I did the changes where String was been used, but I couldn't change where `parseMode?.modeName` is passing to the RequestBody String Converter. For example:
```
//Bot.kt
    fun sendPhoto(
        chatId: Long,
        photo: SystemFile,
        caption: String? = null,
        parseMode: ParseMode? = null,
        disableNotification: Boolean? = null,
        replyToMessageId: Long? = null,
        replyMarkup: ReplyMarkup? = null
    ) = apiClient.sendPhoto(
        chatId,
        photo,
        caption,
        parseMode?.modeName,
        disableNotification,
        replyToMessageId,
        replyMarkup
    ).call()

//ApiClient.kt
    fun sendPhoto(
        chatId: Long,
        photo: SystemFile,
        caption: String?,
        parseMode: String?,
        disableNotification: Boolean?,
        replyToMessageId: Long?,
        replyMarkup: ReplyMarkup?
    ): Call<Response<Message>> {

        return service.sendPhoto(
            convertString(chatId.toString()),
            convertFile("photo", photo),
            if (caption != null) convertString(caption) else null,
            if (parseMode != null) convertString(parseMode) else null,
            if (disableNotification != null) convertString(disableNotification.toString()) else null,
            if (replyToMessageId != null) convertString(replyToMessageId.toString()) else null,
            if (replyMarkup != null) convertJson(replyMarkup.toString()) else null
        )
    }

//ApiService.kt
    @Multipart
    @POST("sendPhoto")
    fun sendPhoto(
        @Part("chat_id") chatId: RequestBody,
        @Part photo: MultipartBody.Part,
        @Part("caption") caption: RequestBody?,
        @Part("parse_mode") parseMode: RequestBody?,
        @Part("disable_notification") disableNotification: RequestBody?,
        @Part("reply_to_message_id") replyToMessageId: RequestBody?,
        @Part("reply_markup") replyMarkup: RequestBody? = null
    ): Call<Response<Message>>
```

If you have any suggestions of how can I get the value from @SerializedName or something, I'll be glad to make these changes.