### PR TITLE
Fix chat permissions related API operations #104

### DIFF
--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -736,7 +736,7 @@ class Bot private constructor(
         chatId: Long,
         userId: Long,
         chatPermissions: ChatPermissions,
-        untilDate: Date? = null
+        untilDate: Long? = null // unix time - https://en.wikipedia.org/wiki/Unix_time
     ) = apiClient.restrictChatMember(
         chatId,
         userId,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/ChatPermissions.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/ChatPermissions.kt
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName as Name
 
 data class ChatPermissions(
     @Name("can_send_messages") val canSendMessages: Boolean? = null,
-    @Name("can_send_media_messages") val canSendMediaMessages: Boolean?,
+    @Name("can_send_media_messages") val canSendMediaMessages: Boolean? = null,
     @Name("can_send_polls") val canSendPolls: Boolean? = null,
     @Name("canSendOtherMessages") val canSendOtherMessages: Boolean? = null,
     @Name("can_add_web_page_previews") val canAddWebPagePreviews: Boolean? = null,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -819,13 +819,13 @@ class ApiClient(
         chatId: Long,
         userId: Long,
         chatPermissions: ChatPermissions,
-        untilDate: Date?
+        untilDate: Long? = null
     ): Call<Response<Boolean>> {
 
         return service.restrictChatMember(
             chatId,
             userId,
-            chatPermissions,
+            gson.toJson(chatPermissions),
             untilDate
         )
     }
@@ -859,7 +859,7 @@ class ApiClient(
 
     fun setChatPermissions(chatId: Long, permissions: ChatPermissions): Call<Response<Boolean>> {
 
-        return service.setChatPermissions(chatId, permissions)
+        return service.setChatPermissions(chatId, gson.toJson(permissions))
     }
 
     fun exportChatInviteLink(chatId: Long): Call<Response<String>> {

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
@@ -4,7 +4,6 @@ import com.github.kotlintelegrambot.entities.BotCommand
 import com.github.kotlintelegrambot.entities.Chat
 import com.github.kotlintelegrambot.entities.ChatAction
 import com.github.kotlintelegrambot.entities.ChatMember
-import com.github.kotlintelegrambot.entities.ChatPermissions
 import com.github.kotlintelegrambot.entities.Message
 import com.github.kotlintelegrambot.entities.ParseMode
 import com.github.kotlintelegrambot.entities.ReplyMarkup
@@ -444,8 +443,8 @@ interface ApiService {
     fun restrictChatMember(
         @Field("chat_id") chatId: Long,
         @Field("user_id") userId: Long,
-        @Field("permissions") permissions: ChatPermissions,
-        @Field("until_date") untilDate: Date?
+        @Field("permissions") permissions: String,
+        @Field("until_date") untilDate: Long?
     ): Call<Response<Boolean>>
 
     @FormUrlEncoded
@@ -467,7 +466,7 @@ interface ApiService {
     @POST("setChatPermissions")
     fun setChatPermissions(
         @Field("chat_id") chatId: Long,
-        @Field("permissions") permissions: ChatPermissions
+        @Field("permissions") permissions: String
     ): Call<Response<Boolean>>
 
     @FormUrlEncoded

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/RestrictChatMembersIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/RestrictChatMembersIT.kt
@@ -1,0 +1,102 @@
+package com.github.kotlintelegrambot.network.apiclient
+
+import com.github.kotlintelegrambot.entities.ChatPermissions
+import com.github.kotlintelegrambot.testutils.decode
+import junit.framework.TestCase.assertEquals
+import okhttp3.mockwebserver.MockResponse
+import org.junit.jupiter.api.Test
+
+class RestrictChatMembersIT : ApiClientIT() {
+
+    @Test
+    fun `restrictChatMember with no chat permissions sends the correct request`() {
+        givenRestrictChatMembersSuccessResponse()
+
+        sut.restrictChatMember(
+            ANY_CHAT_ID,
+            ANY_USER_ID,
+            ChatPermissions()
+        ).execute()
+
+        val request = mockWebServer.takeRequest()
+        val expectedRequestBody = "chat_id=1241242&user_id=32523623&permissions={}"
+        assertEquals(expectedRequestBody, request.body.readUtf8().decode())
+    }
+
+    @Test
+    fun `restrictChatMember with one chat permission sends the correct request`() {
+        givenRestrictChatMembersSuccessResponse()
+
+        sut.restrictChatMember(
+            ANY_CHAT_ID,
+            ANY_USER_ID,
+            ChatPermissions(canSendMessages = false)
+        ).execute()
+
+        val request = mockWebServer.takeRequest()
+        val expectedRequestBody = "chat_id=1241242&" +
+                "user_id=32523623&" +
+                "permissions={\"can_send_messages\":false}"
+        assertEquals(expectedRequestBody, request.body.readUtf8().decode())
+    }
+
+    @Test
+    fun `restrictChatMember with several chat permission sends the correct request`() {
+        givenRestrictChatMembersSuccessResponse()
+
+        sut.restrictChatMember(
+            ANY_CHAT_ID,
+            ANY_USER_ID,
+            ChatPermissions(
+                canSendMessages = false,
+                canSendPolls = true,
+                canAddWebPagePreviews = false
+            )
+        ).execute()
+
+        val request = mockWebServer.takeRequest()
+        val expectedRequestBody = "chat_id=1241242&" +
+                "user_id=32523623&" +
+                "permissions={\"can_send_messages\":false," +
+                "\"can_send_polls\":true," +
+                "\"can_add_web_page_previews\":false}"
+        assertEquals(expectedRequestBody, request.body.readUtf8().decode())
+    }
+
+    @Test
+    fun `restrictChatMember with until date sends the correct request`() {
+        givenRestrictChatMembersSuccessResponse()
+
+        sut.restrictChatMember(
+            ANY_CHAT_ID,
+            ANY_USER_ID,
+            ChatPermissions(),
+            ANY_TIMESTAMP
+        ).execute()
+
+        val request = mockWebServer.takeRequest()
+        val expectedRequestBody = "chat_id=1241242&" +
+                "user_id=32523623&permissions={}&" +
+                "until_date=132523523"
+        assertEquals(expectedRequestBody, request.body.readUtf8().decode())
+    }
+
+    private fun givenRestrictChatMembersSuccessResponse() {
+        val restrictChatMembersResponseBody = """
+            {
+                "ok": true,
+                "result": true 
+            }
+        """.trimIndent()
+        val mockedSuccessResponse = MockResponse()
+            .setResponseCode(200)
+            .setBody(restrictChatMembersResponseBody)
+        mockWebServer.enqueue(mockedSuccessResponse)
+    }
+
+    private companion object {
+        const val ANY_CHAT_ID = 1241242L
+        const val ANY_USER_ID = 32523623L
+        const val ANY_TIMESTAMP = 132523523L
+    }
+}

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SetChatPermissionsIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SetChatPermissionsIT.kt
@@ -1,0 +1,74 @@
+package com.github.kotlintelegrambot.network.apiclient
+
+import com.github.kotlintelegrambot.entities.ChatPermissions
+import com.github.kotlintelegrambot.testutils.decode
+import junit.framework.TestCase
+import okhttp3.mockwebserver.MockResponse
+import org.junit.jupiter.api.Test
+
+class SetChatPermissionsIT : ApiClientIT() {
+
+    @Test
+    fun `setChatPermissions with no chat permissions sends the correct request`() {
+        givenSetChatPermissionsSuccessResponse()
+
+        sut.setChatPermissions(ANY_CHAT_ID, ChatPermissions()).execute()
+
+        val request = mockWebServer.takeRequest()
+        val expectedRequestBody = "chat_id=1241242&permissions={}"
+        TestCase.assertEquals(expectedRequestBody, request.body.readUtf8().decode())
+    }
+
+    @Test
+    fun `setChatPermissions with one chat permission sends the correct request`() {
+        givenSetChatPermissionsSuccessResponse()
+
+        sut.setChatPermissions(
+            ANY_CHAT_ID,
+            ChatPermissions(canSendMessages = false)
+        ).execute()
+
+        val request = mockWebServer.takeRequest()
+        val expectedRequestBody = "chat_id=1241242&" +
+                "permissions={\"can_send_messages\":false}"
+        TestCase.assertEquals(expectedRequestBody, request.body.readUtf8().decode())
+    }
+
+    @Test
+    fun `setChatPermissions with several chat permission sends the correct request`() {
+        givenSetChatPermissionsSuccessResponse()
+
+        sut.setChatPermissions(
+            ANY_CHAT_ID,
+            ChatPermissions(
+                canSendMessages = false,
+                canSendPolls = true,
+                canAddWebPagePreviews = false
+            )
+        ).execute()
+
+        val request = mockWebServer.takeRequest()
+        val expectedRequestBody = "chat_id=1241242&" +
+                "permissions={\"can_send_messages\":false," +
+                "\"can_send_polls\":true," +
+                "\"can_add_web_page_previews\":false}"
+        TestCase.assertEquals(expectedRequestBody, request.body.readUtf8().decode())
+    }
+
+    private fun givenSetChatPermissionsSuccessResponse() {
+        val setChatPermissionsResponseBody = """
+            {
+                "ok": true,
+                "result": true 
+            }
+        """.trimIndent()
+        val mockedSuccessResponse = MockResponse()
+            .setResponseCode(200)
+            .setBody(setChatPermissionsResponseBody)
+        mockWebServer.enqueue(mockedSuccessResponse)
+    }
+
+    private companion object {
+        const val ANY_CHAT_ID = 1241242L
+    }
+}


### PR DESCRIPTION
The 'restrictChatMember' and 'setChatPermissions' API operations weren't working properly because the 'ChatPermissions' objects weren't being properly serialized. Also, the 'until_date' field in 'restrictChatMember' was wrong - we were passing a human readable date as its value instead of a unix timestamp.

Closes #104 