### PR TITLE
Fix kick chat member API operation

### DIFF
--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -29,7 +29,6 @@ import com.github.kotlintelegrambot.webhook.WebhookConfig
 import com.github.kotlintelegrambot.webhook.WebhookConfigBuilder
 import java.io.File as SystemFile
 import java.net.Proxy
-import java.util.Date
 
 fun bot(body: Bot.Builder.() -> Unit): Bot = Bot.Builder().build(body)
 
@@ -726,8 +725,11 @@ class Bot private constructor(
         }
     }
 
-    fun kickChatMember(chatId: Long, userId: Long, untilDate: Date) =
-        apiClient.kickChatMember(chatId, userId, untilDate).call()
+    fun kickChatMember(
+        chatId: Long,
+        userId: Long,
+        untilDate: Long? = null // unix time - https://en.wikipedia.org/wiki/Unix_time
+    ) = apiClient.kickChatMember(chatId, userId, untilDate).call()
 
     fun unbanChatMember(chatId: Long, userId: Long) =
         apiClient.unbanChatMember(chatId, userId).call()

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -40,7 +40,6 @@ import com.google.gson.reflect.TypeToken
 import java.io.File as SystemFile
 import java.net.Proxy
 import java.nio.file.Files
-import java.util.Date
 import java.util.concurrent.TimeUnit
 import okhttp3.MediaType
 import okhttp3.MultipartBody
@@ -805,7 +804,7 @@ class ApiClient(
         return service.downloadFile("${apiUrl}file/bot$token/$filePath")
     }
 
-    fun kickChatMember(chatId: Long, userId: Long, untilDate: Date): Call<Response<Boolean>> {
+    fun kickChatMember(chatId: Long, userId: Long, untilDate: Long? = null): Call<Response<Boolean>> {
 
         return service.kickChatMember(chatId, userId, untilDate)
     }

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
@@ -23,7 +23,6 @@ import com.github.kotlintelegrambot.entities.polls.PollType
 import com.github.kotlintelegrambot.entities.stickers.MaskPosition
 import com.github.kotlintelegrambot.entities.stickers.StickerSet
 import com.google.gson.Gson
-import java.util.Date
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import okhttp3.ResponseBody
@@ -428,7 +427,7 @@ interface ApiService {
     fun kickChatMember(
         @Field("chat_id") chatId: Long,
         @Field("user_id") userId: Long,
-        @Field("until_date") untilDate: Date
+        @Field("until_date") untilDate: Long?
     ): Call<Response<Boolean>>
 
     @FormUrlEncoded

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/KickChatMemberIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/KickChatMemberIT.kt
@@ -1,0 +1,54 @@
+package com.github.kotlintelegrambot.network.apiclient
+
+import com.github.kotlintelegrambot.testutils.decode
+import junit.framework.TestCase.assertEquals
+import okhttp3.mockwebserver.MockResponse
+import org.junit.jupiter.api.Test
+
+class KickChatMemberIT : ApiClientIT() {
+
+    @Test
+    fun `kickChatMember with no until date sends the correct request`() {
+        givenKickChatMemberSuccessResponse()
+
+        sut.kickChatMember(ANY_CHAT_ID, ANY_USER_ID).execute()
+
+        val request = mockWebServer.takeRequest()
+        val expectedRequestBody = "chat_id=$ANY_CHAT_ID&user_id=$ANY_USER_ID"
+        assertEquals(expectedRequestBody, request.body.readUtf8().decode())
+    }
+
+    @Test
+    fun `kickChatMember with until date sends the correct request`() {
+        givenKickChatMemberSuccessResponse()
+
+        sut.kickChatMember(
+            ANY_CHAT_ID,
+            ANY_USER_ID,
+            ANY_TIMESTAMP
+        ).execute()
+
+        val request = mockWebServer.takeRequest()
+        val expectedRequestBody = "chat_id=$ANY_CHAT_ID&user_id=$ANY_USER_ID&until_date=$ANY_TIMESTAMP"
+        assertEquals(expectedRequestBody, request.body.readUtf8().decode())
+    }
+
+    private fun givenKickChatMemberSuccessResponse() {
+        val kickChatMemberResponseBody = """
+            {
+                "ok": true,
+                "result": true 
+            }
+        """.trimIndent()
+        val mockedSuccessResponse = MockResponse()
+            .setResponseCode(200)
+            .setBody(kickChatMemberResponseBody)
+        mockWebServer.enqueue(mockedSuccessResponse)
+    }
+
+    private companion object {
+        const val ANY_CHAT_ID = 35235234L
+        const val ANY_USER_ID = 23512412L
+        const val ANY_TIMESTAMP = 1235213523L
+    }
+}


### PR DESCRIPTION
We were sending the 'until_date' field as a human readable date instead of as a unix timestamp.

Closes #110