### PR TITLE
Better types for `InlineKeyboardButton`

### DIFF
--- a/samples/dispatcher/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Main.kt
+++ b/samples/dispatcher/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Main.kt
@@ -97,7 +97,10 @@ fun main(args: Array<String>) {
             }
 
             command("inlineButtons") {
-                val inlineKeyboardMarkup = InlineKeyboardMarkup(generateButtons())
+                val inlineKeyboardMarkup = InlineKeyboardMarkup.create(
+                    listOf(InlineKeyboardButton.CallbackData(text = "Test Inline Button", callbackData = "testButton")),
+                    listOf(InlineKeyboardButton.CallbackData(text = "Show alert", callbackData = "showAlert"))
+                )
                 bot.sendMessage(
                     chatId = message.chat.id,
                     text = "Hello, inline buttons!",
@@ -209,12 +212,5 @@ fun generateUsersButton(): List<List<KeyboardButton>> {
     return listOf(
         listOf(KeyboardButton("Request location (not supported on desktop)", requestLocation = true)),
         listOf(KeyboardButton("Request contact", requestContact = true))
-    )
-}
-
-fun generateButtons(): List<List<InlineKeyboardButton>> {
-    return listOf(
-        listOf(InlineKeyboardButton(text = "Test Inline Button", callbackData = "testButton")),
-        listOf(InlineKeyboardButton(text = "Show alert", callbackData = "showAlert"))
     )
 }

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/InlineKeyboardMarkup.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/InlineKeyboardMarkup.kt
@@ -1,16 +1,36 @@
 package com.github.kotlintelegrambot.entities
 
 import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton
-import com.google.gson.Gson
+import com.github.kotlintelegrambot.network.serialization.GsonFactory
 import com.google.gson.annotations.SerializedName
 
-data class InlineKeyboardMarkup(
+/**
+ * This object represents an inline keyboard that appears right next to the message it belongs to.
+ * @param inlineKeyboard Array of button rows, each represented by an Array of [InlineKeyboardButton] objects.
+ * @see <https://core.telegram.org/bots/api#inlinekeyboardmarkup>
+ */
+class InlineKeyboardMarkup internal constructor(
     @SerializedName("inline_keyboard") val inlineKeyboard: List<List<InlineKeyboardButton>>
 ) : ReplyMarkup {
+
+    init {
+        // Buttons of type [Pay] must always be the first button in the first row.
+        val flattenedButtons = inlineKeyboard.flatten()
+        val payButtons = flattenedButtons.filterIsInstance<InlineKeyboardButton.Pay>()
+        require(payButtons.size <= 1) { "Can't have more than one pay button per inline keyboard" }
+        require(payButtons.size != 1 || flattenedButtons.firstOrNull() is InlineKeyboardButton.Pay) {
+            "Pay buttons must always be the first button in the first row"
+        }
+    }
+
     companion object {
-        private val GSON = Gson()
+        private val GSON = GsonFactory.createForApiClient()
 
         fun createSingleButton(button: InlineKeyboardButton) = InlineKeyboardMarkup(listOf(listOf(button)))
+        fun createSingleRowKeyboard(buttons: List<InlineKeyboardButton>) = InlineKeyboardMarkup(listOf(buttons))
+        fun createSingleRowKeyboard(vararg button: InlineKeyboardButton) = InlineKeyboardMarkup(listOf(button.toList()))
+        fun create(buttons: List<List<InlineKeyboardButton>>) = InlineKeyboardMarkup(buttons)
+        fun create(vararg buttonsRow: List<InlineKeyboardButton>) = InlineKeyboardMarkup(buttonsRow.toList())
     }
 
     override fun toString(): String = GSON.toJson(this)

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/keyboard/InlineKeyboardButton.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/keyboard/InlineKeyboardButton.kt
@@ -1,11 +1,55 @@
 package com.github.kotlintelegrambot.entities.keyboard
 
-import com.google.gson.annotations.SerializedName as Name
+import com.google.gson.annotations.SerializedName
 
-data class InlineKeyboardButton(
-    val text: String,
-    val url: String? = null,
-    @Name("callback_data") val callbackData: String? = null,
-    @Name("switch_inline_query") val switchInlineQuery: String? = null,
-    @Name("switch_inline_query_current_chat") val switchInlineQueryCurrentChat: String? = null
-)
+/**
+ * Represents one button of an inline keyboard ([loginUrl] not supported yet).
+ * @see <https://core.telegram.org/bots/api#inlinekeyboardbutton>
+ */
+sealed class InlineKeyboardButton {
+    abstract val text: String
+
+    /**
+     * HTTP or tg:// url to be opened when button is pressed.
+     */
+    data class Url(
+        override val text: String,
+        val url: String
+    ) : InlineKeyboardButton()
+
+    /**
+     * Data to be sent in a callback query to the bot when button is pressed (1-64 bytes).
+     */
+    data class CallbackData(
+        override val text: String,
+        @SerializedName("callback_data") val callbackData: String
+    ) : InlineKeyboardButton()
+
+    /**
+     * Pressing the button will prompt the user to select one of their chats, open the chat and
+     * insert the bot's username and the specified inline query in the input field. Can be empty,
+     * in which case just the bot's username will be inserted.
+     */
+    data class SwitchInlineQuery(
+        override val text: String,
+        @SerializedName("switch_inline_query") val switchInlineQuery: String
+    ) : InlineKeyboardButton()
+
+    /**
+     * Pressing the button will insert the bot's username and the specified inline query in the
+     * current chat's input field. Can be empty, in which case only the bot's username will be
+     * inserted.
+     */
+    data class SwitchInlineQueryCurrentChat(
+        override val text: String,
+        @SerializedName("switch_inline_query_current_chat") val switchInlineQueryCurrentChat: String
+    ) : InlineKeyboardButton()
+
+    /**
+     * To send a pay button.
+     * NOTE: this type of button must always be the first button in the first row.
+     */
+    data class Pay(override val text: String) : InlineKeyboardButton() {
+        val pay = true
+    }
+}

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/serialization/GsonFactory.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/serialization/GsonFactory.kt
@@ -4,8 +4,10 @@ import com.github.kotlintelegrambot.entities.TelegramFile
 import com.github.kotlintelegrambot.entities.dice.DiceEmoji
 import com.github.kotlintelegrambot.entities.inlinequeryresults.InlineQueryResult
 import com.github.kotlintelegrambot.entities.inputmedia.GroupableMedia
+import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton
 import com.github.kotlintelegrambot.network.serialization.adapter.DiceEmojiAdapter
 import com.github.kotlintelegrambot.network.serialization.adapter.GroupableMediaAdapter
+import com.github.kotlintelegrambot.network.serialization.adapter.InlineKeyboardButtonAdapter
 import com.github.kotlintelegrambot.network.serialization.adapter.InlineQueryResultAdapter
 import com.github.kotlintelegrambot.network.serialization.adapter.InputMediaAdapter
 import com.github.kotlintelegrambot.network.serialization.adapter.TelegramFileAdapter
@@ -16,6 +18,7 @@ object GsonFactory {
 
     fun createForApiClient(): Gson = GsonBuilder()
         .registerTypeAdapter(InlineQueryResult::class.java, InlineQueryResultAdapter())
+        .registerTypeAdapter(InlineKeyboardButton::class.java, InlineKeyboardButtonAdapter())
         .registerTypeAdapter(DiceEmoji::class.java, DiceEmojiAdapter())
         .create()
 

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/serialization/adapter/InlineKeyboardButtonAdapter.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/serialization/adapter/InlineKeyboardButtonAdapter.kt
@@ -1,0 +1,64 @@
+package com.github.kotlintelegrambot.network.serialization.adapter
+
+import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton
+import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton.CallbackData
+import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton.Pay
+import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton.SwitchInlineQuery
+import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton.SwitchInlineQueryCurrentChat
+import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton.Url
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonSerializationContext
+import com.google.gson.JsonSerializer
+import com.google.gson.annotations.SerializedName
+import java.lang.reflect.Type
+
+class InlineKeyboardButtonAdapter : JsonSerializer<InlineKeyboardButton>, JsonDeserializer<InlineKeyboardButton> {
+
+    private class InlineKeyboardButtonDto(
+        val text: String,
+        val url: String? = null,
+        @SerializedName("callback_data") val callbackData: String? = null,
+        @SerializedName("switch_inline_query") val switchInlineQuery: String? = null,
+        @SerializedName("switch_inline_query_current_chat") val switchInlineQueryCurrentChat: String? = null,
+        val pay: Boolean? = null
+    )
+
+    override fun serialize(
+        src: InlineKeyboardButton,
+        typeOfSrc: Type,
+        context: JsonSerializationContext
+    ): JsonElement = when (src) {
+        is Url -> context.serialize(src, Url::class.java)
+        is CallbackData -> context.serialize(src, CallbackData::class.java)
+        is SwitchInlineQuery -> context.serialize(src, SwitchInlineQuery::class.java)
+        is SwitchInlineQueryCurrentChat -> context.serialize(src, SwitchInlineQueryCurrentChat::class.java)
+        is Pay -> context.serialize(src, Pay::class.java)
+    }
+
+    override fun deserialize(
+        json: JsonElement,
+        typeOfT: Type,
+        context: JsonDeserializationContext
+    ): InlineKeyboardButton {
+        val inlineKeyboardButtonDto = context.deserialize<InlineKeyboardButtonDto>(
+            json,
+            InlineKeyboardButtonDto::class.java
+        )
+
+        return with(inlineKeyboardButtonDto) {
+            when {
+                url != null -> Url(text, url)
+                callbackData != null -> CallbackData(text, callbackData)
+                switchInlineQuery != null -> SwitchInlineQuery(text, switchInlineQuery)
+                switchInlineQueryCurrentChat != null -> SwitchInlineQueryCurrentChat(
+                    text,
+                    switchInlineQueryCurrentChat
+                )
+                pay != null -> Pay(text)
+                else -> error("unsupported inline keyboard button $inlineKeyboardButtonDto")
+            }
+        }
+    }
+}

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/entities/InlineKeyboardMarkupTest.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/entities/InlineKeyboardMarkupTest.kt
@@ -1,0 +1,52 @@
+package com.github.kotlintelegrambot.entities
+
+import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton
+import java.lang.IllegalArgumentException
+import junit.framework.TestCase.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class InlineKeyboardMarkupTest {
+
+    @Test
+    fun `can't create an inline keyboard with two pay buttons`() {
+        assertThrows<IllegalArgumentException> {
+            InlineKeyboardMarkup.create(
+                listOf(InlineKeyboardButton.Pay("1")),
+                listOf(InlineKeyboardButton.Pay("2"))
+            )
+        }
+    }
+
+    @Test
+    fun `can't create an inline keyboard with a pay button not first in first row`() {
+        assertThrows<IllegalArgumentException> {
+            InlineKeyboardMarkup.createSingleRowKeyboard(
+                InlineKeyboardButton.Url("1", "https://www.github.com"),
+                InlineKeyboardButton.Pay("2")
+            )
+        }
+    }
+
+    @Test
+    fun `create an inline keyboard with pay button first in first row`() {
+        val payButton = InlineKeyboardButton.Pay("1")
+        val urlButton = InlineKeyboardButton.Url("3", "http://noone.com")
+
+        val inlineKeyboard = InlineKeyboardMarkup.createSingleRowKeyboard(payButton, urlButton)
+
+        assertEquals(payButton, inlineKeyboard.inlineKeyboard.flatten().first())
+        assertEquals(urlButton, inlineKeyboard.inlineKeyboard.flatten().last())
+    }
+
+    @Test
+    fun `create an inline keyboard with url buttons`() {
+        val urlButton1 = InlineKeyboardButton.Url("3", "http://noone.com")
+        val urlButton2 = InlineKeyboardButton.Url("5", "http://noone.com/2")
+
+        val inlineKeyboard = InlineKeyboardMarkup.create(listOf(urlButton1), listOf(urlButton2))
+
+        assertEquals(urlButton1, inlineKeyboard.inlineKeyboard.flatten().first())
+        assertEquals(urlButton2, inlineKeyboard.inlineKeyboard.flatten().last())
+    }
+}

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendMessageIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendMessageIT.kt
@@ -2,8 +2,10 @@ package com.github.kotlintelegrambot.network.apiclient
 
 import com.github.kotlintelegrambot.entities.Chat
 import com.github.kotlintelegrambot.entities.ForceReplyMarkup
+import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
 import com.github.kotlintelegrambot.entities.Message
 import com.github.kotlintelegrambot.entities.ParseMode.MARKDOWN
+import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton
 import com.github.kotlintelegrambot.testutils.decode
 import junit.framework.TestCase.assertEquals
 import okhttp3.mockwebserver.MockResponse
@@ -75,6 +77,42 @@ class SendMessageIT : ApiClientIT() {
     }
 
     @Test
+    fun `sendMessage with inline keyboard is properly sent`() {
+        givenAnySendMessageResponse()
+
+        sut.sendMessage(
+            channelUsername = ANY_CHANNEL_USERNAME,
+            text = ANY_TEXT,
+            parseMode = null,
+            disableWebPagePreview = null,
+            disableNotification = null,
+            replyToMessageId = null,
+            replyMarkup = InlineKeyboardMarkup.create(
+                listOf(
+                    InlineKeyboardButton.Url(ANY_TEXT, ANY_URL),
+                    InlineKeyboardButton.CallbackData(ANY_TEXT, ANY_TEXT)
+                ),
+                listOf(
+                    InlineKeyboardButton.SwitchInlineQuery(ANY_TEXT, ANY_TEXT),
+                    InlineKeyboardButton.SwitchInlineQueryCurrentChat(ANY_TEXT, ANY_TEXT)
+                )
+            )
+        ).execute()
+
+        val request = mockWebServer.takeRequest()
+        val expectedRequestBody = "chat_id=$ANY_CHANNEL_USERNAME" +
+                "&text=$ANY_TEXT" +
+                "&reply_markup={\"inline_keyboard\":[[" +
+                "{\"text\":\"Mucho texto\",\"url\":\"https://www.github.com/vjgarciag96\"}," +
+                "{\"text\":\"Mucho texto\",\"callback_data\":\"Mucho texto\"}" +
+                "],[" +
+                "{\"text\":\"Mucho texto\",\"switch_inline_query\":\"Mucho texto\"}," +
+                "{\"text\":\"Mucho texto\",\"switch_inline_query_current_chat\":\"Mucho texto\"}" +
+                "]]}"
+        assertEquals(expectedRequestBody, request.body.readUtf8().decode())
+    }
+
+    @Test
     fun `sendMessage response is returned correctly`() {
         givenAnySendMessageResponse()
 
@@ -130,5 +168,6 @@ class SendMessageIT : ApiClientIT() {
         const val ANY_CHANNEL_USERNAME = "testtelegrambotapi"
         const val ANY_MESSAGE_ID = 35235423L
         const val ANY_TEXT = "Mucho texto"
+        const val ANY_URL = "https://www.github.com/vjgarciag96"
     }
 }

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/serialization/adapter/InlineKeyboardButtonAdapterTest.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/serialization/adapter/InlineKeyboardButtonAdapterTest.kt
@@ -1,0 +1,106 @@
+package com.github.kotlintelegrambot.network.serialization.adapter
+
+import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton
+import com.google.gson.GsonBuilder
+import junit.framework.TestCase.assertEquals
+import org.junit.jupiter.api.Test
+
+class InlineKeyboardButtonAdapterTest {
+
+    private val sut = GsonBuilder().registerTypeAdapter(
+        InlineKeyboardButton::class.java,
+        InlineKeyboardButtonAdapter()
+    ).create()
+
+    @Test
+    fun `serialize and deserialize inline keyboard url button`() {
+        val urlButton = InlineKeyboardButton.Url(
+            text = ANY_TEXT,
+            url = ANY_URL
+        )
+        val urlButtonJson = """{"text":"$ANY_TEXT","url":"$ANY_URL"}"""
+
+        val actualUrlButton = sut.fromJson(urlButtonJson, InlineKeyboardButton::class.java)
+        val actualUrlButtonJson = sut.toJson(urlButton)
+
+        assertEquals(urlButton, actualUrlButton)
+        assertEquals(urlButtonJson, actualUrlButtonJson)
+    }
+
+    @Test
+    fun `serialize and deserialize inline keyboard callback data button`() {
+        val callbackDataButton = InlineKeyboardButton.CallbackData(
+            text = ANY_TEXT,
+            callbackData = ANY_CALLBACK_DATA
+        )
+        val callbackDataButtonJson = """{"text":"$ANY_TEXT","callback_data":"$ANY_CALLBACK_DATA"}"""
+
+        val actualCallbackDataButton = sut.fromJson(
+            callbackDataButtonJson,
+            InlineKeyboardButton::class.java
+        )
+        val actualCallbackDataButtonJson = sut.toJson(callbackDataButton)
+
+        assertEquals(callbackDataButton, actualCallbackDataButton)
+        assertEquals(callbackDataButtonJson, actualCallbackDataButtonJson)
+    }
+
+    @Test
+    fun `serialize and deserialize inline keyboard switch inline query button`() {
+        val switchInlineQueryButton = InlineKeyboardButton.SwitchInlineQuery(
+            text = ANY_TEXT,
+            switchInlineQuery = ANY_SWITCH_INLINE_QUERY
+        )
+        val switchInlineQueryButtonJson =
+            """{"text":"$ANY_TEXT","switch_inline_query":"$ANY_SWITCH_INLINE_QUERY"}"""
+
+        val actualSwitchInlineQueryButton = sut.fromJson(
+            switchInlineQueryButtonJson,
+            InlineKeyboardButton::class.java
+        )
+        val actualSwitchInlineQueryButtonJson = sut.toJson(switchInlineQueryButton)
+
+        assertEquals(switchInlineQueryButton, actualSwitchInlineQueryButton)
+        assertEquals(switchInlineQueryButtonJson, actualSwitchInlineQueryButtonJson)
+    }
+
+    @Test
+    fun `serialize and deserialize inline keyboard switch inline query current chat button`() {
+        val switchInlineQueryCurrentChatButton = InlineKeyboardButton.SwitchInlineQueryCurrentChat(
+            text = ANY_TEXT,
+            switchInlineQueryCurrentChat = ANY_SWITCH_INLINE_QUERY
+        )
+        val switchInlineQueryCurrentChatButtonJson =
+            """{"text":"$ANY_TEXT","switch_inline_query_current_chat":"$ANY_SWITCH_INLINE_QUERY"}"""
+
+        val actualSwitchInlineQueryCurrentChatButton = sut.fromJson(
+            switchInlineQueryCurrentChatButtonJson,
+            InlineKeyboardButton::class.java
+        )
+        val actualSwitchInlineQueryCurrentChatJsonButton = sut.toJson(
+            switchInlineQueryCurrentChatButton
+        )
+
+        assertEquals(switchInlineQueryCurrentChatButton, actualSwitchInlineQueryCurrentChatButton)
+        assertEquals(switchInlineQueryCurrentChatButtonJson, actualSwitchInlineQueryCurrentChatJsonButton)
+    }
+
+    @Test
+    fun `serialize and deserialize inline keyboard pay button`() {
+        val payButton = InlineKeyboardButton.Pay(ANY_TEXT)
+        val payButtonJson = """{"pay":true,"text":"$ANY_TEXT"}"""
+
+        val actualPayButton = sut.fromJson(payButtonJson, InlineKeyboardButton::class.java)
+        val actualPayButtonJson = sut.toJson(actualPayButton)
+
+        assertEquals(payButton, actualPayButton)
+        assertEquals(payButtonJson, actualPayButtonJson)
+    }
+
+    private companion object {
+        const val ANY_TEXT = "Button :P"
+        const val ANY_URL = "https://www.github.com/vjgarciag96"
+        const val ANY_CALLBACK_DATA = "callback_data"
+        const val ANY_SWITCH_INLINE_QUERY = "switch inline query"
+    }
+}


### PR DESCRIPTION
Now there are different Kotlin classes for the different inline keyboard button types rather than only one class with optional properties. Also, correctness of inline keyboards composed by inline keyboard buttons is now enforced by the `InlineKeyboardMarkup` class.

Fixes #113