### PR TITLE
Deserialize `InlineKeyboardButton`s properly when processing webhook updates

### DIFF
--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -23,10 +23,12 @@ import com.github.kotlintelegrambot.logging.LogLevel
 import com.github.kotlintelegrambot.network.ApiClient
 import com.github.kotlintelegrambot.network.bimap
 import com.github.kotlintelegrambot.network.call
+import com.github.kotlintelegrambot.network.serialization.GsonFactory
 import com.github.kotlintelegrambot.types.DispatchableObject
 import com.github.kotlintelegrambot.updater.Updater
 import com.github.kotlintelegrambot.webhook.WebhookConfig
 import com.github.kotlintelegrambot.webhook.WebhookConfigBuilder
+import com.google.gson.Gson
 import java.io.File as SystemFile
 import java.net.Proxy
 
@@ -50,9 +52,11 @@ class Bot private constructor(
     apiUrl: String,
     timeout: Int = 30,
     logLevel: LogLevel,
-    proxy: Proxy
+    proxy: Proxy,
+    gson: Gson
 ) {
-    private val apiClient: ApiClient = ApiClient(token, apiUrl, timeout, logLevel, proxy)
+
+    private val apiClient: ApiClient = ApiClient(token, apiUrl, timeout, logLevel, proxy, gson)
 
     init {
         updater.bot = this
@@ -62,7 +66,8 @@ class Bot private constructor(
 
     class Builder {
         val updater = Updater()
-        private val updateMapper = UpdateMapper()
+        private val gson = GsonFactory.createForApiClient()
+        private val updateMapper = UpdateMapper(gson)
         var webhookConfig: WebhookConfig? = null
         lateinit var token: String
         var timeout: Int = 30
@@ -71,12 +76,12 @@ class Bot private constructor(
         var proxy: Proxy = Proxy.NO_PROXY
 
         fun build(): Bot {
-            return Bot(updater, updateMapper, webhookConfig, token, apiUrl, timeout, logLevel, proxy)
+            return Bot(updater, updateMapper, webhookConfig, token, apiUrl, timeout, logLevel, proxy, gson)
         }
 
         fun build(body: Bot.Builder.() -> Unit): Bot {
             body()
-            return Bot(updater, updateMapper, webhookConfig, token, apiUrl, timeout, logLevel, proxy)
+            return Bot(updater, updateMapper, webhookConfig, token, apiUrl, timeout, logLevel, proxy, gson)
         }
     }
 

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/UpdateMapper.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/UpdateMapper.kt
@@ -3,7 +3,7 @@ package com.github.kotlintelegrambot
 import com.github.kotlintelegrambot.entities.Update
 import com.google.gson.Gson
 
-internal class UpdateMapper(private val gson: Gson = Gson()) {
+internal class UpdateMapper(private val gson: Gson) {
 
     fun jsonToUpdate(updateJson: String): Update = gson.fromJson(updateJson, Update::class.java)
 }

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/CallbackQuery.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/CallbackQuery.kt
@@ -1,11 +1,12 @@
 package com.github.kotlintelegrambot.entities
 
-import com.google.gson.annotations.SerializedName as Name
+import com.google.gson.annotations.SerializedName
 
 data class CallbackQuery(
     val id: String,
     val from: User,
     val message: Message? = null,
-    @Name("inline_message_id") val inlineMessageId: String? = null,
-    val data: String
+    @SerializedName("inline_message_id") val inlineMessageId: String? = null,
+    val data: String,
+    @SerializedName("chat_instance") val chatInstance: String
 )

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/InlineKeyboardMarkup.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/InlineKeyboardMarkup.kt
@@ -9,7 +9,7 @@ import com.google.gson.annotations.SerializedName
  * @param inlineKeyboard Array of button rows, each represented by an Array of [InlineKeyboardButton] objects.
  * @see <https://core.telegram.org/bots/api#inlinekeyboardmarkup>
  */
-class InlineKeyboardMarkup internal constructor(
+data class InlineKeyboardMarkup internal constructor(
     @SerializedName("inline_keyboard") val inlineKeyboard: List<List<InlineKeyboardButton>>
 ) : ReplyMarkup {
 

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/Update.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/Update.kt
@@ -9,7 +9,7 @@ import com.google.gson.annotations.SerializedName as Name
 
 data class Update constructor(
     @Name("update_id") val updateId: Long,
-    val message: Message?,
+    val message: Message? = null,
     @Name("edited_message") val editedMessage: Message? = null,
     @Name("channel_post") val channelPost: Message? = null,
     @Name("edited_channel_post") val editedChannelPost: Message? = null,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -96,7 +96,7 @@ class ApiClient(
     private val botTimeout: Int = 30,
     logLevel: LogLevel,
     proxy: Proxy = Proxy.NO_PROXY,
-    private val gson: Gson = GsonFactory.createForApiClient(),
+    private val gson: Gson,
     private val multipartBodyFactory: MultipartBodyFactory = MultipartBodyFactory(GsonFactory.createForMultipartBodyFactory())
 ) {
 

--- a/telegram/src/test/kotlin/Mothers.kt
+++ b/telegram/src/test/kotlin/Mothers.kt
@@ -336,13 +336,15 @@ fun anyCallbackQuery(
     from: User = anyUser(),
     message: Message? = null,
     inlineMessageId: String? = null,
-    data: String = "anyData"
+    data: String = "anyData",
+    chatInstance: String = "1"
 ): CallbackQuery = CallbackQuery(
     id = id,
     from = from,
     message = message,
     inlineMessageId = inlineMessageId,
-    data = data
+    data = data,
+    chatInstance = chatInstance
 )
 
 fun anyInlineQuery(

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/UpdateMapperTest.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/UpdateMapperTest.kt
@@ -1,0 +1,123 @@
+package com.github.kotlintelegrambot
+
+import com.github.kotlintelegrambot.entities.CallbackQuery
+import com.github.kotlintelegrambot.entities.Chat
+import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
+import com.github.kotlintelegrambot.entities.Message
+import com.github.kotlintelegrambot.entities.Update
+import com.github.kotlintelegrambot.entities.User
+import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton.CallbackData
+import com.github.kotlintelegrambot.network.serialization.GsonFactory
+import junit.framework.TestCase.assertEquals
+import org.junit.jupiter.api.Test
+
+class UpdateMapperTest {
+
+    private val sut = UpdateMapper(
+        gson = GsonFactory.createForApiClient()
+    )
+
+    @Test
+    fun `update with callback query containing an inline keyboard is mapped correctly`() {
+        val updateJson = """
+            {
+                "update_id": 1,
+                "callback_query": {
+                    "id": "1",
+                    "from": {
+                        "id": 1,
+                        "is_bot": false,
+                        "first_name": "TestName",
+                        "username": "testname",
+                        "language_code": "de"
+                    },
+                    "message": {
+                        "message_id": 1,
+                        "from": {
+                            "id": 1,
+                            "is_bot": true,
+                            "first_name": "testbot",
+                            "username": "testbot"
+                        },
+                        "chat": {
+                            "id": 1,
+                            "first_name": "TestName",
+                            "username": "testname",
+                            "type": "private"
+                        },
+                        "date": 1606317592,
+                        "text": "Hello, inline buttons!",
+                        "reply_markup": {
+                            "inline_keyboard": [
+                                [
+                                    {
+                                        "text": "Test Inline Button",
+                                        "callback_data": "testButton"
+                                    }
+                                ],
+                                [
+                                    {
+                                        "text": "Show alert",
+                                        "callback_data": "showAlert"
+                                    }
+                                ]
+                            ]
+                        }
+                    },
+                    "chat_instance": "1",
+                    "data": "showAlert"
+                }
+            }
+        """.trimIndent()
+
+        val actualUpdate = sut.jsonToUpdate(updateJson)
+
+        val expectedUpdate = Update(
+            updateId = 1,
+            callbackQuery = CallbackQuery(
+                id = "1",
+                from = User(
+                    id = 1,
+                    isBot = false,
+                    firstName = "TestName",
+                    username = "testname",
+                    languageCode = "de"
+                ),
+                message = Message(
+                    messageId = 1,
+                    from = User(
+                        id = 1,
+                        isBot = true,
+                        firstName = "testbot",
+                        username = "testbot"
+                    ),
+                    chat = Chat(
+                        id = 1,
+                        firstName = "TestName",
+                        username = "testname",
+                        type = "private"
+                    ),
+                    date = 1606317592,
+                    text = "Hello, inline buttons!",
+                    replyMarkup = InlineKeyboardMarkup.create(
+                        listOf(
+                            CallbackData(
+                                text = "Test Inline Button",
+                                callbackData = "testButton"
+                            )
+                        ),
+                        listOf(
+                            CallbackData(
+                                text = "Show alert",
+                                callbackData = "showAlert"
+                            )
+                        )
+                    )
+                ),
+                chatInstance = "1",
+                data = "showAlert"
+            )
+        )
+        assertEquals(expectedUpdate, actualUpdate)
+    }
+}

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/ApiClientIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/ApiClientIT.kt
@@ -2,6 +2,7 @@ package com.github.kotlintelegrambot.network.apiclient
 
 import com.github.kotlintelegrambot.logging.LogLevel
 import com.github.kotlintelegrambot.network.ApiClient
+import com.github.kotlintelegrambot.network.serialization.GsonFactory
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -16,7 +17,12 @@ abstract class ApiClientIT {
     fun setUp() {
         mockWebServer.start()
         val webServerUrl = mockWebServer.url("")
-        sut = ApiClient(token = "", apiUrl = webServerUrl.toString(), logLevel = LogLevel.None)
+        sut = ApiClient(
+            token = "",
+            apiUrl = webServerUrl.toString(),
+            logLevel = LogLevel.None,
+            gson = GsonFactory.createForApiClient()
+        )
     }
 
     @AfterEach

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/GetUpdatesIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/GetUpdatesIT.kt
@@ -1,0 +1,134 @@
+package com.github.kotlintelegrambot.network.apiclient
+
+import com.github.kotlintelegrambot.entities.CallbackQuery
+import com.github.kotlintelegrambot.entities.Chat
+import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
+import com.github.kotlintelegrambot.entities.Message
+import com.github.kotlintelegrambot.entities.Update
+import com.github.kotlintelegrambot.entities.User
+import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton
+import junit.framework.TestCase.assertEquals
+import okhttp3.mockwebserver.MockResponse
+import org.junit.jupiter.api.Test
+
+class GetUpdatesIT : ApiClientIT() {
+
+    @Test
+    fun `getUpdates returning an update with callback query containing inline keyboard buttons`() {
+        givenGetUpdatesResponse("""
+            {
+                "ok": true,
+                "result": [
+                    {
+                        "update_id": 1,
+                        "callback_query": {
+                            "id": "1",
+                            "from": {
+                                "id": 1,
+                                "is_bot": false,
+                                "first_name": "TestName",
+                                "username": "testname",
+                                "language_code": "de"
+                            },
+                            "message": {
+                                "message_id": 1,
+                                "from": {
+                                    "id": 1,
+                                    "is_bot": true,
+                                    "first_name": "testbot",
+                                    "username": "testbot"
+                                },
+                                "chat": {
+                                    "id": 1,
+                                    "first_name": "TestName",
+                                    "username": "testname",
+                                    "type": "private"
+                                },
+                                "date": 1606317592,
+                                "text": "Hello, inline buttons!",
+                                "reply_markup": {
+                                    "inline_keyboard": [
+                                        [
+                                            {
+                                                "text": "Test Inline Button",
+                                                "callback_data": "testButton"
+                                            }
+                                        ],
+                                        [
+                                            {
+                                                "text": "Show alert",
+                                                "callback_data": "showAlert"
+                                            }
+                                        ]
+                                    ]
+                                }
+                            },
+                            "chat_instance": "1",
+                            "data": "showAlert"
+                        }
+                    }
+                ]
+            }
+        """.trimIndent())
+
+        val getUpdatesResult = sut.getUpdates().execute()
+
+        val expectedUpdates = listOf(
+            Update(
+                updateId = 1,
+                callbackQuery = CallbackQuery(
+                    id = "1",
+                    from = User(
+                        id = 1,
+                        isBot = false,
+                        firstName = "TestName",
+                        username = "testname",
+                        languageCode = "de"
+                    ),
+                    message = Message(
+                        messageId = 1,
+                        from = User(
+                            id = 1,
+                            isBot = true,
+                            firstName = "testbot",
+                            username = "testbot"
+                        ),
+                        chat = Chat(
+                            id = 1,
+                            firstName = "TestName",
+                            username = "testname",
+                            type = "private"
+                        ),
+                        date = 1606317592,
+                        text = "Hello, inline buttons!",
+                        replyMarkup = InlineKeyboardMarkup.create(
+                            listOf(
+                                InlineKeyboardButton.CallbackData(
+                                    text = "Test Inline Button",
+                                    callbackData = "testButton"
+                                )
+                            ),
+                            listOf(
+                                InlineKeyboardButton.CallbackData(
+                                    text = "Show alert",
+                                    callbackData = "showAlert"
+                                )
+                            )
+                        )
+                    ),
+                    chatInstance = "1",
+                    data = "showAlert"
+                )
+            )
+        )
+        val actualUpdates: List<Update> = getUpdatesResult.body()?.result!!
+        assertEquals(expectedUpdates, actualUpdates)
+    }
+
+    private fun givenGetUpdatesResponse(getUpdatesResponseJson: String) {
+        val mockedResponse = MockResponse()
+            .setResponseCode(200)
+            .setBody(getUpdatesResponseJson)
+        mockWebServer.enqueue(mockedResponse)
+    }
+}


### PR DESCRIPTION
Fixes #126 

* Use the correct `Gson` instance in `UpdateMapper` class.
* Extra: Add `chat_instance` field to `CallbackQuery`.
* Extra: Fix `InlineKeyboardMarkup` equality (making it a data class).
* Extra: Add default value for the `message` propery in `Update` class.