### PR TITLE
Make update consumable

### DIFF
--- a/docs/gettingUpdates.md
+++ b/docs/gettingUpdates.md
@@ -29,6 +29,23 @@ bot {
 
 For a more detailed example you can check the `dispatcher` and `echo` samples you can find in the `samples` folder of this project.
 
+### Update consumption
+Usually the `dispatcher` calls all the handlers which satisfy update parameters. If update was handled you can implicitly call `update.consume()` to mark the update as consumed so other handlers won't get it:  
+```kotlin
+bot { 
+    dispatcher {
+        text {  
+            if (text == 'Hello World!') {
+                update.consume()
+            }  
+        }
+        text {
+            // This handler will not get an update.
+        }
+    }
+}
+``` 
+
 
 ## Setting up a webhook
 

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Dispatcher.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Dispatcher.kt
@@ -16,7 +16,7 @@ class Dispatcher(
     internal lateinit var logLevel: LogLevel
     lateinit var bot: Bot
 
-    private val commandHandlers = mutableMapOf<String, ArrayList<Handler>>()
+    private val commandHandlers = linkedMapOf<String, ArrayList<Handler>>()
     private val errorHandlers = arrayListOf<ErrorHandler>()
     private var stopped = false
 
@@ -64,6 +64,9 @@ class Dispatcher(
             group.value
                 .filter { it.checkUpdate(update) }
                 .forEach {
+                    if (update.consumed) {
+                        return
+                    }
                     try {
                         it.handlerCallback(bot, update)
                     } catch (exc: Exception) {

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/Update.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/Update.kt
@@ -4,6 +4,7 @@ import com.github.kotlintelegrambot.entities.payments.PreCheckoutQuery
 import com.github.kotlintelegrambot.entities.payments.ShippingQuery
 import com.github.kotlintelegrambot.entities.polls.Poll
 import com.github.kotlintelegrambot.entities.polls.PollAnswer
+import com.github.kotlintelegrambot.types.ConsumableObject
 import com.github.kotlintelegrambot.types.DispatchableObject
 import com.google.gson.annotations.SerializedName as Name
 
@@ -20,7 +21,7 @@ data class Update constructor(
     @Name("pre_checkout_query") val preCheckoutQuery: PreCheckoutQuery? = null,
     @Name("poll") val poll: Poll? = null,
     @Name("poll_answer") val pollAnswer: PollAnswer? = null
-) : DispatchableObject
+) : DispatchableObject, ConsumableObject()
 
 /**
  * Generate list of key-value from start payload.

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/types/ConsumableObject.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/types/ConsumableObject.kt
@@ -1,0 +1,14 @@
+package com.github.kotlintelegrambot.types
+
+abstract class ConsumableObject {
+
+    var consumed: Boolean = false
+        private set
+
+    fun consume() {
+        if (consumed) {
+            throw IllegalStateException("This object has already been consumed.")
+        }
+        consumed = true
+    }
+}

--- a/telegram/src/test/kotlin/DispatcherTest.kt
+++ b/telegram/src/test/kotlin/DispatcherTest.kt
@@ -1,13 +1,17 @@
 import com.github.kotlintelegrambot.Bot
 import com.github.kotlintelegrambot.dispatcher.Dispatcher
+import com.github.kotlintelegrambot.dispatcher.handlers.HandleText
 import com.github.kotlintelegrambot.dispatcher.handlers.HandleUpdate
 import com.github.kotlintelegrambot.dispatcher.handlers.Handler
+import com.github.kotlintelegrambot.dispatcher.handlers.TextHandler
 import com.github.kotlintelegrambot.logging.LogLevel
 import com.github.kotlintelegrambot.types.DispatchableObject
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import io.mockk.verifyOrder
 import java.util.concurrent.BlockingQueue
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class DispatcherTest {
@@ -15,20 +19,32 @@ class DispatcherTest {
     private val botMock = mockk<Bot>()
     private val blockingQueueMock = mockk<BlockingQueue<DispatchableObject>>()
 
-    private val sut = Dispatcher(blockingQueueMock).apply {
+    private fun dispatcher() = Dispatcher(blockingQueueMock).apply {
         bot = botMock
         logLevel = LogLevel.None
     }
 
-    @Test
-    fun `updates are dispatched to handlers when updates check starts and there are some updates`() {
-        val handlerCallbackMock = mockk<HandleUpdate>(relaxed = true)
-        val handlerMock = mockk<Handler> {
+    private fun mockHandler(
+        handlerCallbackMock: HandleUpdate,
+        groupIdentifierMock: String = ""
+    ): Handler {
+        return mockk {
             every { handlerCallback } returns handlerCallbackMock
             every { checkUpdate(any()) } returns true
-            every { groupIdentifier } returns ""
+            every { groupIdentifier } returns groupIdentifierMock
         }
-        sut.addHandler(handlerMock)
+    }
+
+    private companion object {
+        const val ANY_TEXT = "Valar Morghulis"
+    }
+
+    @Test
+    fun `updates are dispatched to handlers when updates check starts and there are some updates`() {
+        val sut = dispatcher()
+
+        val handlerCallbackMock = mockk<HandleUpdate>(relaxed = true)
+        sut.addHandler(mockHandler(handlerCallbackMock))
         val anyUpdate = anyUpdate()
         every { blockingQueueMock.take() } returns anyUpdate andThenThrows InterruptedException()
 
@@ -37,6 +53,57 @@ class DispatcherTest {
         } catch (exception: InterruptedException) {
         } finally {
             verify(exactly = 1) { handlerCallbackMock(botMock, anyUpdate) }
+        }
+    }
+
+    @Test
+    fun `handlers are not called after update is consumed`() {
+        val sut = dispatcher()
+        val anyMessageWithText = anyUpdate(message = anyMessage(text = ANY_TEXT))
+        val firstHandler = TextHandler(text = null, handleText = {
+            if (text == ANY_TEXT) {
+                update.consume()
+            }
+        })
+
+        val handlerCallbackMock = mockk<HandleText>(relaxed = true)
+        val secondHandler = TextHandler(text = null, handleText = handlerCallbackMock)
+
+        sut.addHandler(firstHandler)
+        sut.addHandler(secondHandler)
+
+        every { blockingQueueMock.take() } returns anyMessageWithText andThenThrows InterruptedException()
+        try {
+            sut.startCheckingUpdates()
+        } catch (exception: InterruptedException) {
+        } finally {
+            assertTrue(anyMessageWithText.consumed)
+            verify(exactly = 0) { handlerCallbackMock(any()) }
+        }
+    }
+
+    @Test
+    fun `test that handlers from different groups are called in consistent order`() {
+        val sut = dispatcher()
+        val firstHandlerCallbackMock = mockk<HandleUpdate>(relaxed = true)
+        val secondHandlerCallbackMock = mockk<HandleUpdate>(relaxed = true)
+        val thirdHandlerCallbackMock = mockk<HandleUpdate>(relaxed = true)
+        sut.addHandler(mockHandler(firstHandlerCallbackMock, "Group 1"))
+        sut.addHandler(mockHandler(secondHandlerCallbackMock, "Group 2"))
+        sut.addHandler(mockHandler(thirdHandlerCallbackMock, "Group 3"))
+
+        val anyUpdate = anyUpdate()
+        every { blockingQueueMock.take() } returns anyUpdate andThenThrows InterruptedException()
+
+        try {
+            sut.startCheckingUpdates()
+        } catch (exception: InterruptedException) {
+        } finally {
+            verifyOrder {
+                firstHandlerCallbackMock(botMock, anyUpdate)
+                secondHandlerCallbackMock(botMock, anyUpdate)
+                thirdHandlerCallbackMock(botMock, anyUpdate)
+            }
         }
     }
 }

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/types/ConsumableObjectTest.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/types/ConsumableObjectTest.kt
@@ -1,0 +1,21 @@
+package com.github.kotlintelegrambot.types
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class ConsumableObjectTest {
+
+    @Test
+    fun `test that consumbale object cannot be consumed twice`() {
+        val consumableObject = object : ConsumableObject() {}
+
+        assertFalse(consumableObject.consumed)
+        consumableObject.consume()
+        assertTrue(consumableObject.consumed)
+        assertThrows<IllegalStateException> {
+            consumableObject.consume()
+        }
+    }
+}


### PR DESCRIPTION
Issue: #141 

### Summary
1. Update now inherits from ConsumableObject, so it can be marked as consumed by the handler.
2. Command handlers now use LinkedHashMap instead of HashMap to preserve and insertion order of handlers.

### Possible next steps
* Use numeric priorities for the handlers to sort them and don't rely on insertion order.

### As per contribution guidelines
```sh 
▶ ./gradlew ktlintFormat
BUILD SUCCESSFUL in 13s
6 actionable tasks: 6 executed

▶ ./gradlew check
BUILD SUCCESSFUL in 27s
16 actionable tasks: 15 executed, 1 up-to-date
```