### PR TITLE
Chat id parameter refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ fun main(args: Array<String>) {
         dispatch {
             text { bot, update ->
                 val text = update.message?.text ?: "Hello, World!"
-                bot.sendMessage(chatId = update.message!!.chat.id, text = text)
+                bot.sendMessage(ChatId.fromId(chatId = update.message!!.chat.id), text = text)
             }
         }
     }
@@ -42,7 +42,7 @@ fun main(args: Array<String>) {
         token = "YOUR_API_KEY"
         dispatch {
             command("start") {
-                val result = bot.sendMessage(chatId = message.chat.id, text = "Hi there!")
+                val result = bot.sendMessage(chatId = ChatId.fromId(message.chat.id), text = "Hi there!")
                 result.fold({
                     // do something here with the response
                 },{

--- a/samples/dispatcher/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Main.kt
+++ b/samples/dispatcher/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Main.kt
@@ -3,7 +3,6 @@ package com.github.kotlintelegrambot.dispatcher
 import com.github.kotlintelegrambot.bot
 import com.github.kotlintelegrambot.dispatch
 import com.github.kotlintelegrambot.entities.ChatId
-import com.github.kotlintelegrambot.entities.ChatId.Companion
 import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
 import com.github.kotlintelegrambot.entities.KeyboardReplyMarkup
 import com.github.kotlintelegrambot.entities.ParseMode.MARKDOWN

--- a/samples/dispatcher/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Main.kt
+++ b/samples/dispatcher/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Main.kt
@@ -2,6 +2,7 @@ package com.github.kotlintelegrambot.dispatcher
 
 import com.github.kotlintelegrambot.bot
 import com.github.kotlintelegrambot.dispatch
+import com.github.kotlintelegrambot.entities.ChatId
 import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
 import com.github.kotlintelegrambot.entities.KeyboardReplyMarkup
 import com.github.kotlintelegrambot.entities.ParseMode.MARKDOWN
@@ -29,16 +30,16 @@ fun main(args: Array<String>) {
 
         dispatch {
             message(Filter.Sticker) {
-                bot.sendMessage(message.chat.id, text = "You have received an awesome sticker \\o/")
+                bot.sendMessage(ChatId.fromId(message.chat.id), text = "You have received an awesome sticker \\o/")
             }
 
             message(Filter.Reply or Filter.Forward) {
-                bot.sendMessage(message.chat.id, text = "someone is replying or forwarding messages ...")
+                bot.sendMessage(ChatId.fromId(message.chat.id), text = "someone is replying or forwarding messages ...")
             }
 
             command("start") {
 
-                val result = bot.sendMessage(chatId = update.message!!.chat.id, text = "Bot started")
+                val result = bot.sendMessage(chatId = ChatId.fromId(update.message!!.chat.id), text = "Bot started")
 
                 result.fold(
                     {
@@ -52,7 +53,7 @@ fun main(args: Array<String>) {
 
             command("hello") {
 
-                val result = bot.sendMessage(chatId = update.message!!.chat.id, text = "Hello, world!")
+                val result = bot.sendMessage(chatId = ChatId.fromId(update.message!!.chat.id), text = "Hello, world!")
 
                 result.fold(
                     {
@@ -67,13 +68,13 @@ fun main(args: Array<String>) {
             command("commandWithArgs") {
                 val joinedArgs = args.joinToString()
                 val response = if (joinedArgs.isNotBlank()) joinedArgs else "There is no text apart from command!"
-                bot.sendMessage(chatId = message.chat.id, text = response)
+                bot.sendMessage(chatId = ChatId.fromId(message.chat.id), text = response)
             }
 
             command("markdown") {
                 val markdownText = "_Cool message_: *Markdown* is `beatiful` :P"
                 bot.sendMessage(
-                    chatId = message.chat.id,
+                    chatId = ChatId.fromId(message.chat.id),
                     text = markdownText,
                     parseMode = MARKDOWN
                 )
@@ -96,7 +97,7 @@ fun main(args: Array<String>) {
                     ```
                 """.trimIndent()
                 bot.sendMessage(
-                    chatId = message.chat.id,
+                    chatId = ChatId.fromId(message.chat.id),
                     text = markdownV2Text,
                     parseMode = MARKDOWN_V2
                 )
@@ -108,7 +109,7 @@ fun main(args: Array<String>) {
                     listOf(InlineKeyboardButton.CallbackData(text = "Show alert", callbackData = "showAlert"))
                 )
                 bot.sendMessage(
-                    chatId = message.chat.id,
+                    chatId = ChatId.fromId(message.chat.id),
                     text = "Hello, inline buttons!",
                     replyMarkup = inlineKeyboardMarkup
                 )
@@ -117,7 +118,7 @@ fun main(args: Array<String>) {
             command("userButtons") {
                 val keyboardMarkup = KeyboardReplyMarkup(keyboard = generateUsersButton(), resizeKeyboard = true)
                 bot.sendMessage(
-                    chatId = message.chat.id,
+                    chatId = ChatId.fromId(message.chat.id),
                     text = "Hello, users buttons!",
                     replyMarkup = keyboardMarkup
                 )
@@ -142,7 +143,7 @@ fun main(args: Array<String>) {
 
             callbackQuery("testButton") {
                 val chatId = callbackQuery.message?.chat?.id ?: return@callbackQuery
-                bot.sendMessage(chatId, callbackQuery.data)
+                bot.sendMessage(ChatId.fromId(chatId), callbackQuery.data)
             }
 
             callbackQuery(
@@ -151,16 +152,16 @@ fun main(args: Array<String>) {
                 callbackAnswerShowAlert = true
             ) {
                 val chatId = callbackQuery.message?.chat?.id ?: return@callbackQuery
-                bot.sendMessage(chatId, callbackQuery.data)
+                bot.sendMessage(ChatId.fromId(chatId), callbackQuery.data)
             }
 
             text("ping") {
-                bot.sendMessage(chatId = message.chat.id, text = "Pong")
+                bot.sendMessage(chatId = ChatId.fromId(message.chat.id), text = "Pong")
             }
 
             location {
                 bot.sendMessage(
-                    chatId = message.chat.id,
+                    chatId = ChatId.fromId(message.chat.id),
                     text = "Your location is (${location.latitude}, ${location.longitude})",
                     replyMarkup = ReplyKeyboardRemove()
                 )
@@ -168,7 +169,7 @@ fun main(args: Array<String>) {
 
             contact {
                 bot.sendMessage(
-                    chatId = message.chat.id,
+                    chatId = ChatId.fromId(message.chat.id),
                     text = "Hello, ${contact.firstName} ${contact.lastName}",
                     replyMarkup = ReplyKeyboardRemove()
                 )
@@ -196,7 +197,7 @@ fun main(args: Array<String>) {
 
             photos {
                 bot.sendMessage(
-                    chatId = message.chat.id,
+                    chatId = ChatId.fromId(message.chat.id),
                     text = "Wowww, awesome photos!!! :P"
                 )
             }
@@ -206,7 +207,7 @@ fun main(args: Array<String>) {
             }
 
             dice {
-                bot.sendMessage(message.chat.id, "A dice ${dice.emoji.emojiValue} with value ${dice.value} has been received!")
+                bot.sendMessage(ChatId.fromId(message.chat.id), "A dice ${dice.emoji.emojiValue} with value ${dice.value} has been received!")
             }
 
             telegramError {

--- a/samples/dispatcher/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Main.kt
+++ b/samples/dispatcher/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Main.kt
@@ -3,6 +3,7 @@ package com.github.kotlintelegrambot.dispatcher
 import com.github.kotlintelegrambot.bot
 import com.github.kotlintelegrambot.dispatch
 import com.github.kotlintelegrambot.entities.ChatId
+import com.github.kotlintelegrambot.entities.ChatId.Companion
 import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
 import com.github.kotlintelegrambot.entities.KeyboardReplyMarkup
 import com.github.kotlintelegrambot.entities.ParseMode.MARKDOWN
@@ -126,7 +127,7 @@ fun main(args: Array<String>) {
 
             command("mediaGroup") {
                 bot.sendMediaGroup(
-                    chatId = message.chat.id,
+                    chatId = ChatId.fromId(message.chat.id),
                     mediaGroup = MediaGroup.from(
                         InputMediaPhoto(
                             media = ByUrl("https://www.sngular.com/wp-content/uploads/2019/11/Kotlin-Blog-1400x411.png"),
@@ -203,7 +204,7 @@ fun main(args: Array<String>) {
             }
 
             command("diceAsDartboard") {
-                bot.sendDice(message.chat.id, DiceEmoji.Dartboard)
+                bot.sendDice(ChatId.fromId(message.chat.id), DiceEmoji.Dartboard)
             }
 
             dice {

--- a/samples/echo/src/main/kotlin/com/github/kotlintelegrambot/echo/Main.kt
+++ b/samples/echo/src/main/kotlin/com/github/kotlintelegrambot/echo/Main.kt
@@ -3,6 +3,7 @@ package com.github.kotlintelegrambot.echo
 import com.github.kotlintelegrambot.bot
 import com.github.kotlintelegrambot.dispatch
 import com.github.kotlintelegrambot.dispatcher.text
+import com.github.kotlintelegrambot.entities.ChatId
 
 fun main(args: Array<String>) {
 
@@ -13,7 +14,7 @@ fun main(args: Array<String>) {
         dispatch {
 
             text {
-                bot.sendMessage(chatId = message.chat.id, text = text)
+                bot.sendMessage(chatId = ChatId.fromId(message.chat.id), text = text)
             }
         }
     }

--- a/samples/polls/src/main/kotlin/com/github/kotlintelegrambot/polls/Main.kt
+++ b/samples/polls/src/main/kotlin/com/github/kotlintelegrambot/polls/Main.kt
@@ -4,6 +4,8 @@ import com.github.kotlintelegrambot.bot
 import com.github.kotlintelegrambot.dispatch
 import com.github.kotlintelegrambot.dispatcher.command
 import com.github.kotlintelegrambot.dispatcher.pollAnswer
+import com.github.kotlintelegrambot.entities.ChatId
+import com.github.kotlintelegrambot.entities.ChatId.Companion
 import com.github.kotlintelegrambot.entities.polls.PollType.QUIZ
 
 fun main() {
@@ -15,7 +17,7 @@ fun main() {
             }
             command("regularPoll") {
                 bot.sendPoll(
-                    chatId = message.chat.id,
+                    chatId = ChatId.fromId(message.chat.id),
                     question = "Pizza with or without pineapple?",
                     options = listOf("With :(", "Without :)"),
                     isAnonymous = false
@@ -24,7 +26,7 @@ fun main() {
 
             command("quizPoll") {
                 bot.sendPoll(
-                    chatId = message.chat.id,
+                    chatId = Companion.fromId(message.chat.id),
                     type = QUIZ,
                     question = "Java or Kotlin?",
                     options = listOf("Java", "Kotlin"),
@@ -35,7 +37,7 @@ fun main() {
 
             command("closedPoll") {
                 bot.sendPoll(
-                    chatId = message.chat.id,
+                    chatId = Companion.fromId(message.chat.id),
                     type = QUIZ,
                     question = "Foo or Bar?",
                     options = listOf("Foo", "Bar", "FooBar"),

--- a/samples/polls/src/main/kotlin/com/github/kotlintelegrambot/polls/Main.kt
+++ b/samples/polls/src/main/kotlin/com/github/kotlintelegrambot/polls/Main.kt
@@ -5,7 +5,6 @@ import com.github.kotlintelegrambot.dispatch
 import com.github.kotlintelegrambot.dispatcher.command
 import com.github.kotlintelegrambot.dispatcher.pollAnswer
 import com.github.kotlintelegrambot.entities.ChatId
-import com.github.kotlintelegrambot.entities.ChatId.Companion
 import com.github.kotlintelegrambot.entities.polls.PollType.QUIZ
 
 fun main() {
@@ -26,7 +25,7 @@ fun main() {
 
             command("quizPoll") {
                 bot.sendPoll(
-                    chatId = Companion.fromId(message.chat.id),
+                    chatId = ChatId.fromId(message.chat.id),
                     type = QUIZ,
                     question = "Java or Kotlin?",
                     options = listOf("Java", "Kotlin"),
@@ -37,7 +36,7 @@ fun main() {
 
             command("closedPoll") {
                 bot.sendPoll(
-                    chatId = Companion.fromId(message.chat.id),
+                    chatId = ChatId.fromId(message.chat.id),
                     type = QUIZ,
                     question = "Foo or Bar?",
                     options = listOf("Foo", "Bar", "FooBar"),

--- a/samples/webhook/src/main/kotlin/com/github/kotlintelegrambot/webhook/Main.kt
+++ b/samples/webhook/src/main/kotlin/com/github/kotlintelegrambot/webhook/Main.kt
@@ -3,6 +3,7 @@ package com.github.kotlintelegrambot.webhook
 import com.github.kotlintelegrambot.bot
 import com.github.kotlintelegrambot.dispatch
 import com.github.kotlintelegrambot.dispatcher.command
+import com.github.kotlintelegrambot.entities.ChatId
 import com.github.kotlintelegrambot.entities.TelegramFile
 import com.github.kotlintelegrambot.webhook
 import io.ktor.application.call
@@ -36,7 +37,7 @@ fun main() {
         }
         dispatch {
             command("hello") {
-                bot.sendMessage(message.chat.id, "Hey bruh!")
+                bot.sendMessage(ChatId.fromId(message.chat.id), "Hey bruh!")
             }
         }
     }

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -257,7 +257,7 @@ class Bot private constructor(
     ).call()
 
     fun sendPhoto(
-        chatId: Long,
+        chatId: ChatId,
         photo: SystemFile,
         caption: String? = null,
         parseMode: ParseMode? = null,
@@ -275,7 +275,7 @@ class Bot private constructor(
     ).call()
 
     fun sendPhoto(
-        chatId: Long,
+        chatId: ChatId,
         photo: String,
         caption: String? = null,
         parseMode: ParseMode? = null,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -203,6 +203,18 @@ class Bot private constructor(
 
     fun getMe() = apiClient.getMe().call()
 
+    /**
+     * Use this method to send text messages
+     * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+     * @param text text of the message to be sent, 1-4096 characters after entities parsing
+     * @param parseMode mode for parsing entities in the message text
+     * @param disableWebPagePreview disables link previews for links in this message
+     * @param disableNotification sends the message silently - users will receive a notification with no sound
+     * @param replyToMessageId if the message is a reply, ID of the original message
+     * @param replyMarkup additional options - inline keyboard, custom reply keyboard, instructions to remove reply
+     * keyboard or to force a reply from the user
+     * @return the sent [Message] on success
+     */
     fun sendMessage(
         chatId: ChatId,
         text: String,
@@ -949,7 +961,7 @@ class Bot private constructor(
      * - Bots granted `can_post_messages` permissions can delete outgoing messages in channels.
      * - If the bot is an administrator of a group, it can delete any message there.
      * - If the bot has `can_delete_messages` permission in a supergroup or a channel, it can delete any message there.
-     * @param chatId Unique identifier for the target chat.
+     * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
      * @param messageId Identifier of the message to delete.
      * @return True on success.
      */
@@ -1192,7 +1204,7 @@ class Bot private constructor(
 
     /**
      * Use this method to send a dice, which will have a random value from 1 to 6.
-     * @param chatId Unique identifier for the target chat
+     * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
      * @param emoji Emoji on which the dice throw animation is based. Currently, must be one of 🎲 or 🎯. Defaults to 🎲
      * @param disableNotification Sends the message silently. Users will receive a notification with no sound
      * @param replyToMessageId If the message is a reply, ID of the original message
@@ -1215,7 +1227,7 @@ class Bot private constructor(
 
     /**
      * Use this method to set a custom title for an administrator in a supergroup promoted by the bot.
-     * @param chatId Unique identifier for the target chat
+     * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
      * @param userId Unique identifier of the target user
      * @param customTitle New custom title for the administrator; 0-16 characters, emoji are not allowed
      * @return true on success.

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -221,7 +221,7 @@ class Bot private constructor(
     ).call()
 
     fun forwardMessage(
-        chatId: Long,
+        chatId: ChatId,
         fromChatId: Long,
         messageId: Long,
         disableNotification: Boolean? = null

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -499,7 +499,7 @@ class Bot private constructor(
     ).call()
 
     fun sendVoice(
-        chatId: Long,
+        chatId: ChatId,
         audio: ByteArray,
         caption: String? = null,
         parseMode: ParseMode? = null,
@@ -521,7 +521,7 @@ class Bot private constructor(
     ).call()
 
     fun sendVoice(
-        chatId: Long,
+        chatId: ChatId,
         audio: SystemFile,
         caption: String? = null,
         parseMode: ParseMode? = null,
@@ -543,7 +543,7 @@ class Bot private constructor(
     ).call()
 
     fun sendVoice(
-        chatId: Long,
+        chatId: ChatId,
         audioId: String,
         caption: String? = null,
         parseMode: ParseMode? = null,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -407,7 +407,7 @@ class Bot private constructor(
     ).call()
 
     fun sendVideo(
-        chatId: Long,
+        chatId: ChatId,
         video: SystemFile,
         duration: Int? = null,
         width: Int? = null,
@@ -429,7 +429,7 @@ class Bot private constructor(
     ).call()
 
     fun sendVideo(
-        chatId: Long,
+        chatId: ChatId,
         fileId: String,
         duration: Int? = null,
         width: Int? = null,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -351,7 +351,7 @@ class Bot private constructor(
     ).call()
 
     fun sendDocument(
-        chatId: Long,
+        chatId: ChatId,
         document: SystemFile,
         caption: String? = null,
         parseMode: ParseMode? = null,
@@ -369,7 +369,7 @@ class Bot private constructor(
     ).call()
 
     fun sendDocument(
-        chatId: Long,
+        chatId: ChatId,
         fileBytes: ByteArray,
         caption: String? = null,
         parseMode: ParseMode? = null,
@@ -389,7 +389,7 @@ class Bot private constructor(
     ).call()
 
     fun sendDocument(
-        chatId: Long,
+        chatId: ChatId,
         fileId: String,
         caption: String? = null,
         parseMode: ParseMode? = null,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -222,7 +222,7 @@ class Bot private constructor(
 
     fun forwardMessage(
         chatId: ChatId,
-        fromChatId: Long,
+        fromChatId: ChatId,
         messageId: Long,
         disableNotification: Boolean? = null
     ) = apiClient.forwardMessage(
@@ -565,7 +565,7 @@ class Bot private constructor(
     ).call()
 
     fun sendVideoNote(
-        chatId: Long,
+        chatId: ChatId,
         videoNote: SystemFile,
         duration: Int? = null,
         length: Int? = null,
@@ -583,7 +583,7 @@ class Bot private constructor(
     ).call()
 
     fun sendVideoNote(
-        chatId: Long,
+        chatId: ChatId,
         videoNoteId: String,
         duration: Int? = null,
         length: Int? = null,
@@ -601,21 +601,14 @@ class Bot private constructor(
     ).call()
 
     fun sendMediaGroup(
-        chatId: String,
-        mediaGroup: MediaGroup,
-        disableNotification: Boolean? = null,
-        replyToMessageId: Long? = null
-    ) = apiClient.sendMediaGroup(chatId, mediaGroup, disableNotification, replyToMessageId).call()
-
-    fun sendMediaGroup(
-        chatId: Long,
+        chatId: ChatId,
         mediaGroup: MediaGroup,
         disableNotification: Boolean? = null,
         replyToMessageId: Long? = null
     ) = apiClient.sendMediaGroup(chatId, mediaGroup, disableNotification, replyToMessageId).call()
 
     fun sendLocation(
-        chatId: Long,
+        chatId: ChatId,
         latitude: Float,
         longitude: Float,
         livePeriod: Int? = null,
@@ -633,41 +626,7 @@ class Bot private constructor(
     ).call()
 
     fun sendPoll(
-        channelUsername: String,
-        question: String,
-        options: List<String>,
-        isAnonymous: Boolean? = null,
-        type: PollType? = null,
-        allowsMultipleAnswers: Boolean? = null,
-        correctOptionId: Int? = null,
-        explanation: String? = null,
-        explanationParseMode: ParseMode? = null,
-        openPeriod: Int? = null,
-        closeDate: Long? = null,
-        isClosed: Boolean? = null,
-        disableNotification: Boolean? = null,
-        replyToMessageId: Long? = null,
-        replyMarkup: ReplyMarkup? = null
-    ) = apiClient.sendPoll(
-        channelUsername,
-        question,
-        options,
-        isAnonymous,
-        type,
-        allowsMultipleAnswers,
-        correctOptionId,
-        explanation,
-        explanationParseMode,
-        openPeriod,
-        closeDate,
-        isClosed,
-        disableNotification,
-        replyToMessageId,
-        replyMarkup
-    ).call()
-
-    fun sendPoll(
-        chatId: Long,
+        chatId: ChatId,
         question: String,
         options: List<String>,
         isAnonymous: Boolean? = null,
@@ -701,7 +660,7 @@ class Bot private constructor(
     ).call()
 
     fun editMessageLiveLocation(
-        chatId: Long? = null,
+        chatId: ChatId? = null,
         messageId: Long? = null,
         inlineMessageId: String? = null,
         latitude: Float,
@@ -717,7 +676,7 @@ class Bot private constructor(
     ).call()
 
     fun stopMessageLiveLocation(
-        chatId: Long? = null,
+        chatId: ChatId? = null,
         messageId: Long? = null,
         inlineMessageId: String? = null,
         replyMarkup: ReplyMarkup? = null
@@ -729,7 +688,7 @@ class Bot private constructor(
     ).call()
 
     fun sendVenue(
-        chatId: Long,
+        chatId: ChatId,
         latitude: Float,
         longitude: Float,
         title: String,
@@ -753,7 +712,7 @@ class Bot private constructor(
     ).call()
 
     fun sendContact(
-        chatId: Long,
+        chatId: ChatId,
         phoneNumber: String,
         firstName: String,
         lastName: String? = null,
@@ -770,7 +729,7 @@ class Bot private constructor(
         replyMarkup
     ).call()
 
-    fun sendChatAction(chatId: Long, action: ChatAction) =
+    fun sendChatAction(chatId: ChatId, action: ChatAction) =
         apiClient.sendChatAction(chatId, action).call()
 
     fun getUserProfilePhotos(userId: Long, offset: Long? = null, limit: Int? = null) =
@@ -791,16 +750,16 @@ class Bot private constructor(
     }
 
     fun kickChatMember(
-        chatId: Long,
+        chatId: ChatId,
         userId: Long,
         untilDate: Long? = null // unix time - https://en.wikipedia.org/wiki/Unix_time
     ) = apiClient.kickChatMember(chatId, userId, untilDate).call()
 
-    fun unbanChatMember(chatId: Long, userId: Long) =
+    fun unbanChatMember(chatId: ChatId, userId: Long) =
         apiClient.unbanChatMember(chatId, userId).call()
 
     fun restrictChatMember(
-        chatId: Long,
+        chatId: ChatId,
         userId: Long,
         chatPermissions: ChatPermissions,
         untilDate: Long? = null // unix time - https://en.wikipedia.org/wiki/Unix_time
@@ -812,7 +771,7 @@ class Bot private constructor(
     ).call()
 
     fun promoteChatMember(
-        chatId: Long,
+        chatId: ChatId,
         userId: Long,
         canChangeInfo: Boolean? = null,
         canPostMessages: Boolean? = null,
@@ -835,43 +794,43 @@ class Bot private constructor(
         canPromoteMembers
     ).call()
 
-    fun setChatPermissions(chatId: Long, permissions: ChatPermissions) =
+    fun setChatPermissions(chatId: ChatId, permissions: ChatPermissions) =
         apiClient.setChatPermissions(chatId, permissions).call()
 
-    fun exportChatInviteLink(chatId: Long) = apiClient.exportChatInviteLink(chatId).call()
+    fun exportChatInviteLink(chatId: ChatId) = apiClient.exportChatInviteLink(chatId).call()
 
     fun setChatPhoto(
-        chatId: Long,
+        chatId: ChatId,
         photo: SystemFile
     ) =
         apiClient.setChatPhoto(chatId, photo).call()
 
-    fun deleteChatPhoto(chatId: Long) = apiClient.deleteChatPhoto(chatId).call()
+    fun deleteChatPhoto(chatId: ChatId) = apiClient.deleteChatPhoto(chatId).call()
 
-    fun setChatTitle(chatId: Long, title: String) = apiClient.setChatTitle(chatId, title).call()
+    fun setChatTitle(chatId: ChatId, title: String) = apiClient.setChatTitle(chatId, title).call()
 
-    fun setChatDescription(chatId: Long, description: String) =
+    fun setChatDescription(chatId: ChatId, description: String) =
         apiClient.setChatDescription(chatId, description).call()
 
-    fun pinChatMessage(chatId: Long, messageId: Long, disableNotification: Boolean? = null) =
+    fun pinChatMessage(chatId: ChatId, messageId: Long, disableNotification: Boolean? = null) =
         apiClient.pinChatMessage(chatId, messageId, disableNotification).call()
 
-    fun unpinChatMessage(chatId: Long) = apiClient.unpinChatMessage(chatId).call()
+    fun unpinChatMessage(chatId: ChatId) = apiClient.unpinChatMessage(chatId).call()
 
-    fun leaveChat(chatId: Long) = apiClient.leaveChat(chatId).call()
+    fun leaveChat(chatId: ChatId) = apiClient.leaveChat(chatId).call()
 
-    fun getChat(chatId: Long) = apiClient.getChat(chatId).call()
+    fun getChat(chatId: ChatId) = apiClient.getChat(chatId).call()
 
-    fun getChatAdministrators(chatId: Long) = apiClient.getChatAdministrators(chatId).call()
+    fun getChatAdministrators(chatId: ChatId) = apiClient.getChatAdministrators(chatId).call()
 
-    fun getChatMembersCount(chatId: Long) = apiClient.getChatMembersCount(chatId).call()
+    fun getChatMembersCount(chatId: ChatId) = apiClient.getChatMembersCount(chatId).call()
 
-    fun getChatMember(chatId: Long, userId: Long) = apiClient.getChatMember(chatId, userId).call()
+    fun getChatMember(chatId: ChatId, userId: Long) = apiClient.getChatMember(chatId, userId).call()
 
-    fun setChatStickerSet(chatId: Long, stickerSetName: String) =
+    fun setChatStickerSet(chatId: ChatId, stickerSetName: String) =
         apiClient.setChatStickerSet(chatId, stickerSetName).call()
 
-    fun deleteChatStickerSet(chatId: Long) = apiClient.deleteChatStickerSet(chatId).call()
+    fun deleteChatStickerSet(chatId: ChatId) = apiClient.deleteChatStickerSet(chatId).call()
 
     fun answerCallbackQuery(
         callbackQueryId: String,
@@ -892,7 +851,7 @@ class Bot private constructor(
      */
 
     fun editMessageText(
-        chatId: Long? = null,
+        chatId: ChatId? = null,
         messageId: Long? = null,
         inlineMessageId: String? = null,
         text: String,
@@ -910,7 +869,7 @@ class Bot private constructor(
     ).call()
 
     fun editMessageCaption(
-        chatId: Long? = null,
+        chatId: ChatId? = null,
         messageId: Long? = null,
         inlineMessageId: String? = null,
         caption: String,
@@ -924,7 +883,7 @@ class Bot private constructor(
     ).call()
 
     fun editMessageMedia(
-        chatId: Long? = null,
+        chatId: ChatId? = null,
         messageId: Long? = null,
         inlineMessageId: String? = null,
         media: InputMedia,
@@ -938,7 +897,7 @@ class Bot private constructor(
     ).call()
 
     fun editMessageReplyMarkup(
-        chatId: Long? = null,
+        chatId: ChatId? = null,
         messageId: Long? = null,
         inlineMessageId: String? = null,
         replyMarkup: ReplyMarkup? = null
@@ -962,31 +921,15 @@ class Bot private constructor(
      * @param messageId Identifier of the message to delete.
      * @return True on success.
      */
-    fun deleteMessage(chatId: Long, messageId: Long) =
+    fun deleteMessage(chatId: ChatId, messageId: Long) =
         apiClient.deleteMessage(chatId, messageId).call()
-
-    /**
-     * Use this method to delete a message, including service messages, with the following limitations:
-     * - A message can only be deleted if it was sent less than 48 hours ago.
-     * - A dice message in a private chat can only be deleted if it was sent more than 24 hours ago.
-     * - Bots can delete outgoing messages in private chats, groups, and supergroups.
-     * - Bots can delete incoming messages in private chats.
-     * - Bots granted `can_post_messages` permissions can delete outgoing messages in channels.
-     * - If the bot is an administrator of a group, it can delete any message there.
-     * - If the bot has `can_delete_messages` permission in a supergroup or a channel, it can delete any message there.
-     * @param channelUsername Username of the target channel (in the format @channelusername).
-     * @param messageId Identifier of the message to delete.
-     * @return True on success.
-     */
-    fun deleteMessage(channelUsername: String, messageId: Long) =
-        apiClient.deleteMessage(channelUsername, messageId).call()
 
     /***
      * Stickers
      */
 
     fun sendSticker(
-        chatId: Long,
+        chatId: ChatId,
         sticker: SystemFile,
         disableNotification: Boolean? = null,
         replyToMessageId: Long? = null,
@@ -1000,7 +943,7 @@ class Bot private constructor(
     ).call()
 
     fun sendSticker(
-        chatId: Long,
+        chatId: ChatId,
         sticker: String,
         disableNotification: Boolean? = null,
         replyToMessageId: Long? = null,
@@ -1118,7 +1061,7 @@ class Bot private constructor(
      * @see PaymentInvoiceInfo
      */
     fun sendInvoice(
-        chatId: Long,
+        chatId: ChatId,
         paymentInvoiceInfo: PaymentInvoiceInfo,
         disableNotification: Boolean? = null,
         replyToMessageId: Long? = null,
@@ -1225,7 +1168,7 @@ class Bot private constructor(
      * @return the sent Message
      */
     fun sendDice(
-        chatId: Long,
+        chatId: ChatId,
         emoji: DiceEmoji? = null,
         disableNotification: Boolean? = null,
         replyToMessageId: Long? = null,
@@ -1239,52 +1182,15 @@ class Bot private constructor(
     ).call()
 
     /**
-     * Use this method to send a dice, which will have a random value from 1 to 6.
-     * @param channelUsername Username of the target channel (in the format @channelusername)
-     * @param emoji Emoji on which the dice throw animation is based. Currently, must be one of 🎲 or 🎯. Defaults to 🎲
-     * @param disableNotification Sends the message silently. Users will receive a notification with no sound
-     * @param replyToMessageId If the message is a reply, ID of the original message
-     * @param replyMarkup A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user
-     * @return the sent Message
-     */
-    fun sendDice(
-        channelUsername: String,
-        emoji: DiceEmoji? = null,
-        disableNotification: Boolean? = null,
-        replyToMessageId: Long? = null,
-        replyMarkup: ReplyMarkup? = null
-    ) = apiClient.sendDice(
-        channelUsername,
-        emoji,
-        disableNotification,
-        replyToMessageId,
-        replyMarkup
-    ).call()
-
-    /**
      * Use this method to set a custom title for an administrator in a supergroup promoted by the bot.
      * @param chatId Unique identifier for the target chat
      * @param userId Unique identifier of the target user
      * @param customTitle New custom title for the administrator; 0-16 characters, emoji are not allowed
      * @return true on success.
      */
-    fun setChatAdministratorCustomTitle(chatId: Long, userId: Long, customTitle: String) =
+    fun setChatAdministratorCustomTitle(chatId: ChatId, userId: Long, customTitle: String) =
         apiClient.setChatAdministratorCustomTitle(
             chatId,
-            userId,
-            customTitle
-        ).call()
-
-    /**
-     * Use this method to set a custom title for an administrator in a supergroup promoted by the bot.
-     * @param channelUsername Username of the target channel (in the format @channelusername)
-     * @param userId Unique identifier of the target user
-     * @param customTitle New custom title for the administrator; 0-16 characters, emoji are not allowed
-     * @return true on success.
-     */
-    fun setChatAdministratorCustomTitle(channelUsername: String, userId: Long, customTitle: String) =
-        apiClient.setChatAdministratorCustomTitle(
-            channelUsername,
             userId,
             customTitle
         ).call()

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -451,7 +451,7 @@ class Bot private constructor(
     ).call()
 
     fun sendAnimation(
-        chatId: Long,
+        chatId: ChatId,
         animation: SystemFile,
         duration: Int? = null,
         width: Int? = null,
@@ -475,7 +475,7 @@ class Bot private constructor(
     ).call()
 
     fun sendAnimation(
-        chatId: Long,
+        chatId: ChatId,
         fileId: String,
         duration: Int? = null,
         width: Int? = null,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -202,20 +202,8 @@ class Bot private constructor(
 
     fun getMe() = apiClient.getMe().call()
 
-    /**
-     * Use this method to send text messages
-     * @param chatId unique identifier for the target chat
-     * @param text text of the message to be sent, 1-4096 characters after entities parsing
-     * @param parseMode mode for parsing entities in the message text
-     * @param disableWebPagePreview disables link previews for links in this message
-     * @param disableNotification sends the message silently - users will receive a notification with no sound
-     * @param replyToMessageId if the message is a reply, ID of the original message
-     * @param replyMarkup additional options - inline keyboard, custom reply keyboard, instructions to remove reply
-     * keyboard or to force a reply from the user
-     * @return the sent [Message] on success
-     */
     fun sendMessage(
-        chatId: Long,
+        chatId: ChatId,
         text: String,
         parseMode: ParseMode? = null,
         disableWebPagePreview: Boolean? = null,
@@ -224,36 +212,6 @@ class Bot private constructor(
         replyMarkup: ReplyMarkup? = null
     ) = apiClient.sendMessage(
         chatId,
-        text,
-        parseMode,
-        disableWebPagePreview,
-        disableNotification,
-        replyToMessageId,
-        replyMarkup
-    ).call()
-
-    /**
-     * Use this method to send text messages
-     * @param channelUsername username of the target channel (in the format @channelusername)
-     * @param text text of the message to be sent, 1-4096 characters after entities parsing
-     * @param parseMode mode for parsing entities in the message text
-     * @param disableWebPagePreview disables link previews for links in this message
-     * @param disableNotification sends the message silently - users will receive a notification with no sound
-     * @param replyToMessageId if the message is a reply, ID of the original message
-     * @param replyMarkup additional options - inline keyboard, custom reply keyboard, instructions to remove reply
-     * keyboard or to force a reply from the user
-     * @return the sent [Message] on success
-     */
-    fun sendMessage(
-        channelUsername: String,
-        text: String,
-        parseMode: ParseMode? = null,
-        disableWebPagePreview: Boolean? = null,
-        disableNotification: Boolean? = null,
-        replyToMessageId: Long? = null,
-        replyMarkup: ReplyMarkup? = null
-    ) = apiClient.sendMessage(
-        channelUsername,
         text,
         parseMode,
         disableWebPagePreview,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -293,7 +293,7 @@ class Bot private constructor(
     ).call()
 
     fun sendAudio(
-        chatId: Long,
+        chatId: ChatId,
         audio: String,
         caption: String? = null,
         disableNotification: Boolean? = null,
@@ -311,7 +311,7 @@ class Bot private constructor(
     ).call()
 
     fun sendAudio(
-        chatId: Long,
+        chatId: ChatId,
         audio: SystemFile,
         duration: Int? = null,
         performer: String? = null,
@@ -331,7 +331,7 @@ class Bot private constructor(
     ).call()
 
     fun sendAudio(
-        chatId: Long,
+        chatId: ChatId,
         audio: String,
         duration: Int? = null,
         performer: String? = null,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/ChatId.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/ChatId.kt
@@ -4,13 +4,10 @@ package com.github.kotlintelegrambot.entities
  * Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  */
 sealed class ChatId {
-    data class Id(val id: Long) : ChatId() {
-        override fun toString() = id.toString()
-    }
+    data class Id(val id: Long) : ChatId()
 
     class ChannelUsername(username: String) : ChatId() {
         val username: String = if (username.startsWith("@")) username else "@$username"
-        override fun toString() = username
     }
 
     companion object {

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/ChatId.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/ChatId.kt
@@ -4,9 +4,13 @@ package com.github.kotlintelegrambot.entities
  * Unique identifier for the target chat or username of the target channel (in the format @channelusername)
  */
 sealed class ChatId {
-    data class Id(val id: Long) : ChatId()
+    data class Id(val id: Long) : ChatId() {
+        override fun toString() = id.toString()
+    }
+
     class ChannelUsername(username: String) : ChatId() {
         val username: String = if (username.startsWith("@")) username else "@$username"
+        override fun toString() = username
     }
 
     companion object {

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -56,8 +56,8 @@ import java.nio.file.Files
 import java.util.concurrent.TimeUnit
 import java.io.File as SystemFile
 
-private val PLAIN_TEXT_MIME = MediaType.parse("text/plain")
-private val APPLICATION_JSON_MIME = MediaType.parse("application/json")
+val PLAIN_TEXT_MIME = MediaType.parse("text/plain")
+val APPLICATION_JSON_MIME = MediaType.parse("application/json")
 
 private fun convertString(text: String) = RequestBody.create(PLAIN_TEXT_MIME, text)
 private fun convertJson(text: String) = RequestBody.create(APPLICATION_JSON_MIME, text)
@@ -251,7 +251,7 @@ class ApiClient(
         replyMarkup: ReplyMarkup?
     ): Call<Response<Message>> {
         return service.sendPhoto(
-            convertString(chatId.toString()),
+            chatId,
             convertFile("photo", photo),
             if (caption != null) convertString(caption) else null,
             if (parseMode != null) convertString(parseMode) else null,
@@ -293,7 +293,7 @@ class ApiClient(
     ): Call<Response<Message>> {
 
         return service.sendAudio(
-            convertString(chatId.toString()),
+            chatId,
             convertFile("audio", audio),
             if (duration != null) convertString(duration.toString()) else null,
             if (performer != null) convertString(performer) else null,
@@ -338,7 +338,7 @@ class ApiClient(
     ): Call<Response<Message>> {
 
         return service.sendDocument(
-            convertString(chatId.toString()),
+            chatId,
             convertFile("document", document),
             if (caption != null) convertString(caption) else null,
             if (parseMode != null) convertString(parseMode) else null,
@@ -381,7 +381,7 @@ class ApiClient(
     ): Call<Response<Message>> {
 
         return service.sendDocument(
-            convertString(chatId.toString()),
+            chatId,
             fileBytes.toMultipartBodyPart(name = "document", filename = filename),
             if (caption != null) convertString(caption) else null,
             if (parseMode != null) convertString(parseMode) else null,
@@ -404,7 +404,7 @@ class ApiClient(
     ): Call<Response<Message>> {
 
         return service.sendVideo(
-            convertString(chatId.toString()),
+            chatId,
             convertFile("video", video),
             if (duration != null) convertString(duration.toString()) else null,
             if (width != null) convertString(width.toString()) else null,
@@ -455,7 +455,7 @@ class ApiClient(
     ): Call<Response<Message>> {
 
         return service.sendAnimation(
-            convertString(chatId.toString()),
+            chatId,
             convertFile("video", animation),
             if (duration != null) convertString(duration.toString()) else null,
             if (width != null) convertString(width.toString()) else null,
@@ -508,7 +508,7 @@ class ApiClient(
     ): Call<Response<Message>> {
 
         return service.sendVoice(
-            convertString(chatId.toString()),
+            chatId,
             convertFile("voice", audio, "audio/ogg"),
             if (caption != null) convertString(caption) else null,
             if (parseMode != null) convertString(parseMode.modeName) else null,
@@ -558,7 +558,7 @@ class ApiClient(
     ): Call<Response<Message>> {
 
         return service.sendVoice(
-            convertString(chatId.toString()),
+            chatId,
             convertBytes("voice", audio, "audio/ogg"),
             if (caption != null) convertString(caption) else null,
             if (parseMode != null) convertString(parseMode.modeName) else null,
@@ -581,7 +581,7 @@ class ApiClient(
     ): Call<Response<Message>> {
 
         return service.sendVideoNote(
-            convertString(chatId.toString()),
+            chatId,
             convertFile("video_note", videoNote),
             if (duration != null) convertString(duration.toString()) else null,
             if (length != null) convertString(length.toString()) else null,
@@ -859,7 +859,7 @@ class ApiClient(
         chatId: ChatId,
         photo: SystemFile
     ): Call<Response<Boolean>> {
-        return service.setChatPhoto(convertString(chatId.toString()), convertFile("photo", photo))
+        return service.setChatPhoto(chatId, convertFile("photo", photo))
     }
 
     fun deleteChatPhoto(chatId: ChatId): Call<Response<Boolean>> {
@@ -1122,7 +1122,7 @@ class ApiClient(
     ): Call<Response<Message>> {
 
         return service.sendSticker(
-            convertString(chatId.toString()),
+            chatId,
             convertFile("photo", sticker),
             if (disableNotification != null) convertString(disableNotification.toString()) else null,
             if (replyToMessageId != null) convertString(replyToMessageId.toString()) else null,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -204,7 +204,7 @@ class ApiClient(
     }
 
     fun forwardMessage(
-        chatId: Long,
+        chatId: ChatId,
         fromChatId: Long,
         messageId: Long,
         disableNotification: Boolean?

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -493,7 +493,7 @@ class ApiClient(
     }
 
     fun sendVoice(
-        chatId: Long,
+        chatId: ChatId,
         audio: SystemFile,
         caption: String?,
         parseMode: ParseMode?,
@@ -518,7 +518,7 @@ class ApiClient(
     }
 
     fun sendVoice(
-        chatId: Long,
+        chatId: ChatId,
         audioId: String,
         caption: String?,
         parseMode: ParseMode?,
@@ -543,7 +543,7 @@ class ApiClient(
     }
 
     fun sendVoice(
-        chatId: Long,
+        chatId: ChatId,
         audio: ByteArray,
         caption: String?,
         parseMode: ParseMode?,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -279,7 +279,7 @@ class ApiClient(
     }
 
     fun sendAudio(
-        chatId: Long,
+        chatId: ChatId,
         audio: SystemFile,
         duration: Int?,
         performer: String?,
@@ -302,7 +302,7 @@ class ApiClient(
     }
 
     fun sendAudio(
-        chatId: Long,
+        chatId: ChatId,
         audio: String,
         duration: Int?,
         performer: String?,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -125,14 +125,14 @@ class ApiClient(
         val retrofit = Retrofit.Builder()
             .baseUrl("${apiUrl}bot$token/")
             .client(httpClient)
-            .addConverterFactory(GsonConverterFactory.create(gson))
+            .addConverterFactory(ChatIdConverterFactory())
             // In retrofit, Gson is used only for response/request decoding/encoding, but not for @Query/@Url/@Path etc...
             // For them, Retrofit uses Converter.Factory classes to convert any type to String. By default, enums are transformed
             // with BuiltInConverters.ToStringConverter which just calls to the toString() method of a given object.
             // Is needed to provide a special Converter.Factory if a custom transformation is wanted for them.
             .addConverterFactory(EnumRetrofitConverterFactory())
             .addConverterFactory(DiceEmojiConverterFactory())
-            .addConverterFactory(ChatIdConverterFactory())
+            .addConverterFactory(GsonConverterFactory.create(gson))
             .build()
 
         service = retrofit.create(ApiService::class.java)

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -439,7 +439,7 @@ class ApiClient(
     }
 
     fun sendAnimation(
-        chatId: Long,
+        chatId: ChatId,
         animation: SystemFile,
         duration: Int?,
         width: Int?,
@@ -466,7 +466,7 @@ class ApiClient(
     }
 
     fun sendAnimation(
-        chatId: Long,
+        chatId: ChatId,
         fileId: String,
         duration: Int?,
         width: Int?,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -239,7 +239,7 @@ class ApiClient(
     }
 
     fun sendPhoto(
-        chatId: Long,
+        chatId: ChatId,
         photo: SystemFile,
         caption: String?,
         parseMode: String?,
@@ -247,7 +247,6 @@ class ApiClient(
         replyToMessageId: Long?,
         replyMarkup: ReplyMarkup?
     ): Call<Response<Message>> {
-
         return service.sendPhoto(
             convertString(chatId.toString()),
             convertFile("photo", photo),
@@ -260,7 +259,7 @@ class ApiClient(
     }
 
     fun sendPhoto(
-        chatId: Long,
+        chatId: ChatId,
         photo: String,
         caption: String?,
         parseMode: ParseMode?,
@@ -268,7 +267,6 @@ class ApiClient(
         replyToMessageId: Long?,
         replyMarkup: ReplyMarkup?
     ): Call<Response<Message>> {
-
         return service.sendPhoto(
             chatId,
             photo,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -325,7 +325,7 @@ class ApiClient(
     }
 
     fun sendDocument(
-        chatId: Long,
+        chatId: ChatId,
         document: SystemFile,
         caption: String?,
         parseMode: String?,
@@ -346,7 +346,7 @@ class ApiClient(
     }
 
     fun sendDocument(
-        chatId: Long,
+        chatId: ChatId,
         fileId: String,
         caption: String?,
         parseMode: ParseMode?,
@@ -367,7 +367,7 @@ class ApiClient(
     }
 
     fun sendDocument(
-        chatId: Long,
+        chatId: ChatId,
         fileBytes: ByteArray,
         caption: String?,
         parseMode: String?,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -189,7 +189,7 @@ class ApiClient(
     }
 
     fun sendMessage(
-        chatId: Long,
+        chatId: ChatId,
         text: String,
         parseMode: ParseMode?,
         disableWebPagePreview: Boolean?,
@@ -197,30 +197,11 @@ class ApiClient(
         replyToMessageId: Long?,
         replyMarkup: ReplyMarkup?
     ): Call<Response<Message>> {
-
         return service.sendMessage(
             chatId, text, parseMode, disableWebPagePreview, disableNotification,
             replyToMessageId, replyMarkup
         )
     }
-
-    fun sendMessage(
-        channelUsername: String,
-        text: String,
-        parseMode: ParseMode?,
-        disableWebPagePreview: Boolean?,
-        disableNotification: Boolean?,
-        replyToMessageId: Long?,
-        replyMarkup: ReplyMarkup?
-    ): Call<Response<Message>> = service.sendMessage(
-        channelUsername,
-        text,
-        parseMode,
-        disableWebPagePreview,
-        disableNotification,
-        replyToMessageId,
-        replyMarkup
-    )
 
     fun forwardMessage(
         chatId: Long,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -389,7 +389,7 @@ class ApiClient(
     }
 
     fun sendVideo(
-        chatId: Long,
+        chatId: ChatId,
         video: SystemFile,
         duration: Int?,
         width: Int?,
@@ -414,7 +414,7 @@ class ApiClient(
     }
 
     fun sendVideo(
-        chatId: Long,
+        chatId: ChatId,
         fileId: String,
         duration: Int?,
         width: Int?,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -614,7 +614,7 @@ class ApiClient(
 
     /**
      * Use this method to send a group of photos or videos as an album
-     * @param chatId Unique identifier for the target chat
+     * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
      * @param mediaGroup An object describing photos and videos to be sent, must include 2-10 items
      * @param disableNotification Sends the messages silently. Users will receive a notification with no sound
      * @param replyToMessageId If the messages are a reply, ID of the original message

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -205,7 +205,7 @@ class ApiClient(
 
     fun forwardMessage(
         chatId: ChatId,
-        fromChatId: Long,
+        fromChatId: ChatId,
         messageId: Long,
         disableNotification: Boolean?
     ): Call<Response<Message>> {
@@ -568,7 +568,7 @@ class ApiClient(
     }
 
     fun sendVideoNote(
-        chatId: Long,
+        chatId: ChatId,
         videoNote: SystemFile,
         duration: Int?,
         length: Int?,
@@ -589,7 +589,7 @@ class ApiClient(
     }
 
     fun sendVideoNote(
-        chatId: Long,
+        chatId: ChatId,
         videoNoteId: String,
         duration: Int?,
         length: Int?,
@@ -618,7 +618,7 @@ class ApiClient(
      * @return an array of the sent Messages
      */
     fun sendMediaGroup(
-        chatId: Long,
+        chatId: ChatId,
         mediaGroup: MediaGroup,
         disableNotification: Boolean? = null,
         replyToMessageId: Long? = null
@@ -632,31 +632,8 @@ class ApiClient(
         return service.sendMediaGroup(sendMediaGroupMultipartBody)
     }
 
-    /**
-     * Use this method to send a group of photos or videos as an album
-     * @param chatId Username of the target channel (in the format @channelusername)
-     * @param mediaGroup An object describing photos and videos to be sent, must include 2-10 items
-     * @param disableNotification Sends the messages silently. Users will receive a notification with no sound
-     * @param replyToMessageId If the messages are a reply, ID of the original message
-     * @return an array of the sent Messages
-     */
-    fun sendMediaGroup(
-        chatId: String,
-        mediaGroup: MediaGroup,
-        disableNotification: Boolean?,
-        replyToMessageId: Long?
-    ): Call<Response<Array<Message>>> {
-        val sendMediaGroupMultipartBody = multipartBodyFactory.createForSendMediaGroup(
-            chatId,
-            mediaGroup,
-            disableNotification,
-            replyToMessageId
-        )
-        return service.sendMediaGroup(sendMediaGroupMultipartBody)
-    }
-
     fun sendLocation(
-        chatId: Long,
+        chatId: ChatId,
         latitude: Float,
         longitude: Float,
         livePeriod: Int?,
@@ -677,7 +654,7 @@ class ApiClient(
     }
 
     fun editMessageLiveLocation(
-        chatId: Long?,
+        chatId: ChatId?,
         messageId: Long?,
         inlineMessageId: String?,
         latitude: Float,
@@ -696,7 +673,7 @@ class ApiClient(
     }
 
     fun stopMessageLiveLocation(
-        chatId: Long?,
+        chatId: ChatId?,
         messageId: Long?,
         inlineMessageId: String?,
         replyMarkup: ReplyMarkup?
@@ -711,7 +688,7 @@ class ApiClient(
     }
 
     fun sendVenue(
-        chatId: Long,
+        chatId: ChatId,
         latitude: Float,
         longitude: Float,
         title: String,
@@ -738,7 +715,7 @@ class ApiClient(
     }
 
     fun sendContact(
-        chatId: Long,
+        chatId: ChatId,
         phoneNumber: String,
         firstName: String,
         lastName: String?,
@@ -759,7 +736,7 @@ class ApiClient(
     }
 
     fun sendPoll(
-        chatId: Long,
+        chatId: ChatId,
         question: String,
         options: List<String>,
         isAnonymous: Boolean? = null,
@@ -792,41 +769,7 @@ class ApiClient(
         replyMarkup
     )
 
-    fun sendPoll(
-        channelUsername: String,
-        question: String,
-        options: List<String>,
-        isAnonymous: Boolean? = null,
-        type: PollType? = null,
-        allowsMultipleAnswers: Boolean? = null,
-        correctOptionId: Int? = null,
-        explanation: String? = null,
-        explanationParseMode: ParseMode? = null,
-        openPeriod: Int? = null,
-        closeDate: Long? = null,
-        isClosed: Boolean? = null,
-        disableNotification: Boolean? = null,
-        replyToMessageId: Long? = null,
-        replyMarkup: ReplyMarkup? = null
-    ): Call<Response<Message>> = service.sendPoll(
-        channelUsername,
-        question,
-        gson.toJson(options),
-        isAnonymous,
-        type,
-        allowsMultipleAnswers,
-        correctOptionId,
-        explanation,
-        explanationParseMode,
-        openPeriod,
-        closeDate,
-        isClosed,
-        disableNotification,
-        replyToMessageId,
-        replyMarkup
-    )
-
-    fun sendChatAction(chatId: Long, action: ChatAction): Call<Response<Boolean>> {
+    fun sendChatAction(chatId: ChatId, action: ChatAction): Call<Response<Boolean>> {
 
         return service.sendChatAction(chatId, action)
     }
@@ -849,18 +792,18 @@ class ApiClient(
         return service.downloadFile("${apiUrl}file/bot$token/$filePath")
     }
 
-    fun kickChatMember(chatId: Long, userId: Long, untilDate: Long? = null): Call<Response<Boolean>> {
+    fun kickChatMember(chatId: ChatId, userId: Long, untilDate: Long? = null): Call<Response<Boolean>> {
 
         return service.kickChatMember(chatId, userId, untilDate)
     }
 
-    fun unbanChatMember(chatId: Long, userId: Long): Call<Response<Boolean>> {
+    fun unbanChatMember(chatId: ChatId, userId: Long): Call<Response<Boolean>> {
 
         return service.unbanChatMember(chatId, userId)
     }
 
     fun restrictChatMember(
-        chatId: Long,
+        chatId: ChatId,
         userId: Long,
         chatPermissions: ChatPermissions,
         untilDate: Long? = null
@@ -875,7 +818,7 @@ class ApiClient(
     }
 
     fun promoteChatMember(
-        chatId: Long,
+        chatId: ChatId,
         userId: Long,
         canChangeInfo: Boolean?,
         canPostMessages: Boolean?,
@@ -901,40 +844,40 @@ class ApiClient(
         )
     }
 
-    fun setChatPermissions(chatId: Long, permissions: ChatPermissions): Call<Response<Boolean>> {
+    fun setChatPermissions(chatId: ChatId, permissions: ChatPermissions): Call<Response<Boolean>> {
 
         return service.setChatPermissions(chatId, gson.toJson(permissions))
     }
 
-    fun exportChatInviteLink(chatId: Long): Call<Response<String>> {
+    fun exportChatInviteLink(chatId: ChatId): Call<Response<String>> {
 
         return service.exportChatInviteLink(chatId)
     }
 
     fun setChatPhoto(
-        chatId: Long,
+        chatId: ChatId,
         photo: SystemFile
     ): Call<Response<Boolean>> {
         return service.setChatPhoto(convertString(chatId.toString()), convertFile("photo", photo))
     }
 
-    fun deleteChatPhoto(chatId: Long): Call<Response<Boolean>> {
+    fun deleteChatPhoto(chatId: ChatId): Call<Response<Boolean>> {
 
         return service.deleteChatPhoto(chatId)
     }
 
-    fun setChatTitle(chatId: Long, title: String): Call<Response<Boolean>> {
+    fun setChatTitle(chatId: ChatId, title: String): Call<Response<Boolean>> {
 
         return service.setChatTitle(chatId, title)
     }
 
-    fun setChatDescription(chatId: Long, description: String): Call<Response<Boolean>> {
+    fun setChatDescription(chatId: ChatId, description: String): Call<Response<Boolean>> {
 
         return service.setChatDescription(chatId, description)
     }
 
     fun pinChatMessage(
-        chatId: Long,
+        chatId: ChatId,
         messageId: Long,
         disableNotification: Boolean?
     ): Call<Response<Boolean>> {
@@ -942,42 +885,42 @@ class ApiClient(
         return service.pinChatMessage(chatId, messageId, disableNotification)
     }
 
-    fun unpinChatMessage(chatId: Long): Call<Response<Boolean>> {
+    fun unpinChatMessage(chatId: ChatId): Call<Response<Boolean>> {
 
         return service.unpinChatMessage(chatId)
     }
 
-    fun leaveChat(chatId: Long): Call<Response<Boolean>> {
+    fun leaveChat(chatId: ChatId): Call<Response<Boolean>> {
 
         return service.leaveChat(chatId)
     }
 
-    fun getChat(chatId: Long): Call<Response<Chat>> {
+    fun getChat(chatId: ChatId): Call<Response<Chat>> {
 
         return service.getChat(chatId)
     }
 
-    fun getChatAdministrators(chatId: Long): Call<Response<List<ChatMember>>> {
+    fun getChatAdministrators(chatId: ChatId): Call<Response<List<ChatMember>>> {
 
         return service.getChatAdministrators(chatId)
     }
 
-    fun getChatMembersCount(chatId: Long): Call<Response<Int>> {
+    fun getChatMembersCount(chatId: ChatId): Call<Response<Int>> {
 
         return service.getChatMembersCount(chatId)
     }
 
-    fun getChatMember(chatId: Long, userId: Long): Call<Response<ChatMember>> {
+    fun getChatMember(chatId: ChatId, userId: Long): Call<Response<ChatMember>> {
 
         return service.getChatMember(chatId, userId)
     }
 
-    fun setChatStickerSet(chatId: Long, stickerSetName: String): Call<Response<Boolean>> {
+    fun setChatStickerSet(chatId: ChatId, stickerSetName: String): Call<Response<Boolean>> {
 
         return service.setChatStickerSet(chatId, stickerSetName)
     }
 
-    fun deleteChatStickerSet(chatId: Long): Call<Response<Boolean>> {
+    fun deleteChatStickerSet(chatId: ChatId): Call<Response<Boolean>> {
 
         return service.deleteChatStickerSet(chatId)
     }
@@ -1004,7 +947,7 @@ class ApiClient(
      */
 
     fun editMessageText(
-        chatId: Long?,
+        chatId: ChatId?,
         messageId: Long?,
         inlineMessageId: String?,
         text: String,
@@ -1025,7 +968,7 @@ class ApiClient(
     }
 
     fun editMessageCaption(
-        chatId: Long?,
+        chatId: ChatId?,
         messageId: Long?,
         inlineMessageId: String?,
         caption: String,
@@ -1042,7 +985,7 @@ class ApiClient(
     }
 
     fun editMessageMedia(
-        chatId: Long?,
+        chatId: ChatId?,
         messageId: Long?,
         inlineMessageId: String?,
         media: InputMedia,
@@ -1059,7 +1002,7 @@ class ApiClient(
     }
 
     fun editMessageReplyMarkup(
-        chatId: Long?,
+        chatId: ChatId?,
         messageId: Long?,
         inlineMessageId: String?,
         replyMarkup: ReplyMarkup?
@@ -1074,7 +1017,7 @@ class ApiClient(
     }
 
     fun stopPoll(
-        chatId: Long?,
+        chatId: ChatId?,
         messageId: Long?,
         replyMarkup: ReplyMarkup?
     ): Call<Response<Poll>> {
@@ -1086,18 +1029,15 @@ class ApiClient(
         )
     }
 
-    fun deleteMessage(chatId: Long, messageId: Long): Call<Response<Boolean>> =
+    fun deleteMessage(chatId: ChatId, messageId: Long): Call<Response<Boolean>> =
         service.deleteMessage(chatId, messageId)
-
-    fun deleteMessage(channelUsername: String, messageId: Long): Call<Response<Boolean>> =
-        service.deleteMessage(channelUsername, messageId)
 
     /**
      * Payment
      */
 
     fun sendInvoice(
-        chatId: Long,
+        chatId: ChatId,
         title: String,
         description: String,
         payload: String,
@@ -1166,7 +1106,7 @@ class ApiClient(
      */
 
     fun sendSticker(
-        chatId: Long,
+        chatId: ChatId,
         sticker: SystemFile,
         disableNotification: Boolean?,
         replyToMessageId: Long?,
@@ -1183,7 +1123,7 @@ class ApiClient(
     }
 
     fun sendSticker(
-        chatId: Long,
+        chatId: ChatId,
         sticker: String,
         disableNotification: Boolean?,
         replyToMessageId: Long?,
@@ -1345,7 +1285,7 @@ class ApiClient(
     }
 
     fun sendDice(
-        chatId: Long,
+        chatId: ChatId,
         emoji: DiceEmoji? = null,
         disableNotification: Boolean? = null,
         replyToMessageId: Long? = null,
@@ -1358,36 +1298,12 @@ class ApiClient(
         replyMarkup
     )
 
-    fun sendDice(
-        channelUsername: String,
-        emoji: DiceEmoji? = null,
-        disableNotification: Boolean? = null,
-        replyToMessageId: Long? = null,
-        replyMarkup: ReplyMarkup? = null
-    ): Call<Response<Message>> = service.sendDice(
-        channelUsername,
-        emoji,
-        disableNotification,
-        replyToMessageId,
-        replyMarkup
-    )
-
     fun setChatAdministratorCustomTitle(
-        chatId: Long,
+        chatId: ChatId,
         userId: Long,
         customTitle: String
     ): Call<Response<Boolean>> = service.setChatAdministratorCustomTitle(
         chatId,
-        userId,
-        customTitle
-    )
-
-    fun setChatAdministratorCustomTitle(
-        channelUsername: String,
-        userId: Long,
-        customTitle: String
-    ): Call<Response<Boolean>> = service.setChatAdministratorCustomTitle(
-        channelUsername,
         userId,
         customTitle
     )

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
@@ -225,7 +225,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("sendVideo")
     fun sendVideo(
-        @Field("chat_id") chatId: Long,
+        @Field("chat_id") chatId: ChatId,
         @Field("video") fileId: String,
         @Field("duration") duration: Int?,
         @Field("width") width: Int?,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
@@ -101,19 +101,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("sendMessage")
     fun sendMessage(
-        @Field("chat_id") chatId: Long,
-        @Field("text") text: String,
-        @Field("parse_mode") parseMode: ParseMode?,
-        @Field("disable_web_page_preview") disableWebPagePreview: Boolean?,
-        @Field("disable_notification") disableNotification: Boolean?,
-        @Field("reply_to_message_id") replyToMessageId: Long?,
-        @Field("reply_markup") replyMarkup: ReplyMarkup?
-    ): Call<Response<Message>>
-
-    @FormUrlEncoded
-    @POST("sendMessage")
-    fun sendMessage(
-        @Field("chat_id") channelUsername: String,
+        @Field("chat_id") chatId: ChatId,
         @Field("text") text: String,
         @Field("parse_mode") parseMode: ParseMode?,
         @Field("disable_web_page_preview") disableWebPagePreview: Boolean?,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
@@ -149,7 +149,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("sendPhoto")
     fun sendPhoto(
-        @Field("chat_id") chatId: Long,
+        @Field("chat_id") chatId: ChatId,
         @Field("photo") fileId: String,
         @Field("caption") caption: String?,
         @Field("parse_mode") parseMode: ParseMode?,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
@@ -114,7 +114,7 @@ interface ApiService {
     @POST("forwardMessage")
     fun forwardMessage(
         @Field("chat_id") chatId: ChatId,
-        @Field("from_chat_id") fromChatId: Long,
+        @Field("from_chat_id") fromChatId: ChatId,
         @Field("disable_notification") disableNotification: Boolean?,
         @Field("message_id") messageId: Long
     ): Call<Response<Message>>
@@ -309,7 +309,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("sendVideoNote")
     fun sendVideoNote(
-        @Field("chat_id") chatId: Long,
+        @Field("chat_id") chatId: ChatId,
         @Field("video_note") fileId: String,
         @Field("duration") duration: Int?,
         @Field("length") length: Int?,
@@ -325,7 +325,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("sendLocation")
     fun sendLocation(
-        @Field("chat_id") chatId: Long,
+        @Field("chat_id") chatId: ChatId,
         @Field("latitude") latitude: Float,
         @Field("longitude") longitude: Float,
         @Field("live_period") livePeriod: Int?,
@@ -337,7 +337,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("editMessageLiveLocation")
     fun editMessageLiveLocation(
-        @Field("chat_id") chatId: Long?,
+        @Field("chat_id") chatId: ChatId?,
         @Field("message_id") messageId: Long?,
         @Field("inline_message_id") inlineMessageId: String?,
         @Field("latitude") latitude: Float,
@@ -348,7 +348,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("stopMessageLiveLocation")
     fun stopMessageLiveLocation(
-        @Field("chat_id") chatId: Long?,
+        @Field("chat_id") chatId: ChatId?,
         @Field("message_id") messageId: Long?,
         @Field("inline_message_id") inlineMessageId: String?,
         @Field("reply_markup") replyMarkup: ReplyMarkup? = null
@@ -357,7 +357,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("sendVenue")
     fun sendVenue(
-        @Field("chat_id") chatId: Long,
+        @Field("chat_id") chatId: ChatId,
         @Field("latitude") latitude: Float,
         @Field("longitude") longitude: Float,
         @Field("title") title: String,
@@ -372,7 +372,7 @@ interface ApiService {
     @POST("sendContact")
     @FormUrlEncoded
     fun sendContact(
-        @Field("chat_id") chatId: Long,
+        @Field("chat_id") chatId: ChatId,
         @Field("phone_number") phoneNumber: String,
         @Field("first_name") firstName: String,
         @Field("last_name") lastName: String?,
@@ -384,27 +384,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("sendPoll")
     fun sendPoll(
-        @Field(ApiConstants.CHAT_ID) chatId: Long,
-        @Field(PollFields.QUESTION) question: String,
-        @Field(PollFields.OPTIONS) options: String,
-        @Field(PollFields.IS_ANONYMOUS) isAnonymous: Boolean? = null,
-        @Field(PollFields.TYPE) type: PollType? = null,
-        @Field(PollFields.ALLOWS_MULTIPLE_ANSWERS) allowsMultipleAnswers: Boolean? = null,
-        @Field(PollFields.CORRECT_OPTION_ID) correctOptionId: Int? = null,
-        @Field(PollFields.EXPLANATION) explanation: String? = null,
-        @Field(PollFields.EXPLANATION_PARSE_MODE) explanationParseMode: ParseMode? = null,
-        @Field(PollFields.OPEN_PERIOD) openPeriod: Int? = null,
-        @Field(PollFields.CLOSE_DATE) closeDate: Long? = null,
-        @Field(PollFields.IS_CLOSED) isClosed: Boolean? = null,
-        @Field(ApiConstants.DISABLE_NOTIFICATION) disableNotification: Boolean?,
-        @Field(ApiConstants.REPLY_TO_MESSAGE_ID) replyToMessageId: Long?,
-        @Field(ApiConstants.REPLY_MARKUP) replyMarkup: ReplyMarkup? = null
-    ): Call<Response<Message>>
-
-    @FormUrlEncoded
-    @POST("sendPoll")
-    fun sendPoll(
-        @Field(ApiConstants.CHAT_ID) channelUsername: String,
+        @Field(ApiConstants.CHAT_ID) chatId: ChatId,
         @Field(PollFields.QUESTION) question: String,
         @Field(PollFields.OPTIONS) options: String,
         @Field(PollFields.IS_ANONYMOUS) isAnonymous: Boolean? = null,
@@ -424,7 +404,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("sendChatAction")
     fun sendChatAction(
-        @Field("chat_id") chatId: Long,
+        @Field("chat_id") chatId: ChatId,
         @Field("action") action: ChatAction
     ): Call<Response<Boolean>>
 
@@ -448,7 +428,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("kickChatMember")
     fun kickChatMember(
-        @Field("chat_id") chatId: Long,
+        @Field("chat_id") chatId: ChatId,
         @Field("user_id") userId: Long,
         @Field("until_date") untilDate: Long?
     ): Call<Response<Boolean>>
@@ -456,14 +436,14 @@ interface ApiService {
     @FormUrlEncoded
     @POST("unbanChatMember")
     fun unbanChatMember(
-        @Field("chat_id") chatId: Long,
+        @Field("chat_id") chatId: ChatId,
         @Field("user_id") userId: Long
     ): Call<Response<Boolean>>
 
     @FormUrlEncoded
     @POST("restrictChatMember")
     fun restrictChatMember(
-        @Field("chat_id") chatId: Long,
+        @Field("chat_id") chatId: ChatId,
         @Field("user_id") userId: Long,
         @Field("permissions") permissions: String,
         @Field("until_date") untilDate: Long?
@@ -472,7 +452,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("promoteChatMember")
     fun promoteChatMember(
-        @Field("chat_id") chatId: Long,
+        @Field("chat_id") chatId: ChatId,
         @Field("user_id") userId: Long,
         @Field("can_change_info") canChangeInfo: Boolean?,
         @Field("can_post_messages") canPostMessages: Boolean?,
@@ -487,14 +467,14 @@ interface ApiService {
     @FormUrlEncoded
     @POST("setChatPermissions")
     fun setChatPermissions(
-        @Field("chat_id") chatId: Long,
+        @Field("chat_id") chatId: ChatId,
         @Field("permissions") permissions: String
     ): Call<Response<Boolean>>
 
     @FormUrlEncoded
     @POST("exportChatInviteLink")
     fun exportChatInviteLink(
-        @Field("chat_id") chatId: Long
+        @Field("chat_id") chatId: ChatId
     ): Call<Response<String>>
 
     @Multipart
@@ -507,27 +487,27 @@ interface ApiService {
     @FormUrlEncoded
     @POST("deleteChatPhoto")
     fun deleteChatPhoto(
-        @Field("chat_id") chatId: Long
+        @Field("chat_id") chatId: ChatId
     ): Call<Response<Boolean>>
 
     @FormUrlEncoded
     @POST("setChatTitle")
     fun setChatTitle(
-        @Field("chat_id") chatId: Long,
+        @Field("chat_id") chatId: ChatId,
         @Field("title") title: String
     ): Call<Response<Boolean>>
 
     @FormUrlEncoded
     @POST("setChatDescription")
     fun setChatDescription(
-        @Field("chat_id") chatId: Long,
+        @Field("chat_id") chatId: ChatId,
         @Field("description") description: String
     ): Call<Response<Boolean>>
 
     @FormUrlEncoded
     @POST("pinChatMessage")
     fun pinChatMessage(
-        @Field("chat_id") chatId: Long,
+        @Field("chat_id") chatId: ChatId,
         @Field("message_id") messageId: Long,
         @Field("disable_notification") disableNotification: Boolean?
     ): Call<Response<Boolean>>
@@ -535,47 +515,47 @@ interface ApiService {
     @FormUrlEncoded
     @POST("unpinChatMessage")
     fun unpinChatMessage(
-        @Field("chat_id") chatId: Long
+        @Field("chat_id") chatId: ChatId
     ): Call<Response<Boolean>>
 
     @FormUrlEncoded
     @POST("leaveChat")
     fun leaveChat(
-        @Field("chat_id") chatId: Long
+        @Field("chat_id") chatId: ChatId
     ): Call<Response<Boolean>>
 
     @GET("getChat")
     fun getChat(
-        @Query("chat_id") chatId: Long
+        @Query("chat_id") chatId: ChatId
     ): Call<Response<Chat>>
 
     @GET("getChatAdministrators")
     fun getChatAdministrators(
-        @Query("chat_id") chatId: Long
+        @Query("chat_id") chatId: ChatId
     ): Call<Response<List<ChatMember>>>
 
     @GET("getChatMembersCount")
     fun getChatMembersCount(
-        @Query("chat_id") chatId: Long
+        @Query("chat_id") chatId: ChatId
     ): Call<Response<Int>>
 
     @GET("getChatMember")
     fun getChatMember(
-        @Query("chat_id") chatId: Long,
+        @Query("chat_id") chatId: ChatId,
         @Query("user_id") userId: Long
     ): Call<Response<ChatMember>>
 
     @FormUrlEncoded
     @POST("setChatStickerSet")
     fun setChatStickerSet(
-        @Field("chat_id") chatId: Long,
+        @Field("chat_id") chatId: ChatId,
         @Field("sticker_set_name") stickerSetName: String
     ): Call<Response<Boolean>>
 
     @FormUrlEncoded
     @POST("deleteChatStickerSet")
     fun deleteChatStickerSet(
-        @Field("chat_id") chatId: Long
+        @Field("chat_id") chatId: ChatId
     ): Call<Response<Boolean>>
 
     @FormUrlEncoded
@@ -595,7 +575,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("editMessageText")
     fun editMessageText(
-        @Field("chat_id") chatId: Long?,
+        @Field("chat_id") chatId: ChatId?,
         @Field("message_id") messageId: Long?,
         @Field("inline_message_id") inlineMessageId: String?,
         @Field("text") text: String,
@@ -607,7 +587,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("editMessageCaption")
     fun editMessageCaption(
-        @Field("chat_id") chatId: Long?,
+        @Field("chat_id") chatId: ChatId?,
         @Field("message_id") messageId: Long?,
         @Field("inline_message_id") inlineMessageId: String?,
         @Field("caption") caption: String,
@@ -617,7 +597,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("editMessageMedia")
     fun editMessageMedia(
-        @Field("chat_id") chatId: Long?,
+        @Field("chat_id") chatId: ChatId?,
         @Field("message_id") messageId: Long?,
         @Field("inline_message_id") inlineMessageId: String?,
         @Field("media") media: InputMedia,
@@ -627,7 +607,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("editMessageReplyMarkup")
     fun editMessageReplyMarkup(
-        @Field("chat_id") chatId: Long?,
+        @Field("chat_id") chatId: ChatId?,
         @Field("message_id") messageId: Long?,
         @Field("inline_message_id") inlineMessageId: String?,
         @Field("reply_markup") replyMarkup: ReplyMarkup? = null
@@ -636,7 +616,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("stopPoll")
     fun stopPoll(
-        @Field("chat_id") chatId: Long?,
+        @Field("chat_id") chatId: ChatId?,
         @Field("message_id") messageId: Long?,
         @Field("reply_markup") replyMarkup: ReplyMarkup? = null
     ): Call<Response<Poll>>
@@ -644,14 +624,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("deleteMessage")
     fun deleteMessage(
-        @Field("chat_id") chatId: Long,
-        @Field("message_id") messageId: Long
-    ): Call<Response<Boolean>>
-
-    @FormUrlEncoded
-    @POST("deleteMessage")
-    fun deleteMessage(
-        @Field("chat_id") channelUsername: String,
+        @Field("chat_id") chatId: ChatId,
         @Field("message_id") messageId: Long
     ): Call<Response<Boolean>>
 
@@ -672,7 +645,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("sendSticker")
     fun sendSticker(
-        @Field("chat_id") chatId: Long,
+        @Field("chat_id") chatId: ChatId,
         @Field("sticker") fileId: String,
         @Field("disable_notification") disableNotification: Boolean?,
         @Field("reply_to_message_id") replyToMessageId: Long?,
@@ -755,7 +728,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("sendInvoice")
     fun sendInvoice(
-        @Field("chat_id") chatId: Long,
+        @Field("chat_id") chatId: ChatId,
         @Field("title") title: String,
         @Field("description") description: String,
         @Field("payload") payload: String,
@@ -821,17 +794,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST(DiceFields.SEND_DICE_OP_NAME)
     fun sendDice(
-        @Field(ApiConstants.CHAT_ID) chatId: Long,
-        @Field(DiceFields.EMOJI) emoji: DiceEmoji? = null,
-        @Field(ApiConstants.DISABLE_NOTIFICATION) disableNotification: Boolean? = null,
-        @Field(ApiConstants.REPLY_TO_MESSAGE_ID) replyToMessageId: Long? = null,
-        @Field(ApiConstants.REPLY_MARKUP) replyMarkup: ReplyMarkup? = null
-    ): Call<Response<Message>>
-
-    @FormUrlEncoded
-    @POST(DiceFields.SEND_DICE_OP_NAME)
-    fun sendDice(
-        @Field(ApiConstants.CHAT_ID) channelUsername: String,
+        @Field(ApiConstants.CHAT_ID) chatId: ChatId,
         @Field(DiceFields.EMOJI) emoji: DiceEmoji? = null,
         @Field(ApiConstants.DISABLE_NOTIFICATION) disableNotification: Boolean? = null,
         @Field(ApiConstants.REPLY_TO_MESSAGE_ID) replyToMessageId: Long? = null,
@@ -841,15 +804,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST(ApiConstants.SetChatAdministratorCustomTitle.OP_NAME)
     fun setChatAdministratorCustomTitle(
-        @Field(ApiConstants.CHAT_ID) chatId: Long,
-        @Field(ApiConstants.USER_ID) userId: Long,
-        @Field(ApiConstants.SetChatAdministratorCustomTitle.CUSTOM_TITLE) customTitle: String
-    ): Call<Response<Boolean>>
-
-    @FormUrlEncoded
-    @POST(ApiConstants.SetChatAdministratorCustomTitle.OP_NAME)
-    fun setChatAdministratorCustomTitle(
-        @Field(ApiConstants.CHAT_ID) channelUsername: String,
+        @Field(ApiConstants.CHAT_ID) chatId: ChatId,
         @Field(ApiConstants.USER_ID) userId: Long,
         @Field(ApiConstants.SetChatAdministratorCustomTitle.CUSTOM_TITLE) customTitle: String
     ): Call<Response<Boolean>>

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
@@ -283,7 +283,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("sendVoice")
     fun sendVoice(
-        @Field("chat_id") chatId: Long,
+        @Field("chat_id") chatId: ChatId,
         @Field("voice") fileId: String,
         @Field("caption") caption: String?,
         @Field("parse_mode") parseMode: ParseMode?,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
@@ -254,7 +254,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("sendAnimation")
     fun sendAnimation(
-        @Field("chat_id") chatId: Long,
+        @Field("chat_id") chatId: ChatId,
         @Field("animation") fileId: String,
         @Field("duration") duration: Int?,
         @Field("width") width: Int?,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
@@ -137,7 +137,7 @@ interface ApiService {
     @Multipart
     @POST("sendPhoto")
     fun sendPhoto(
-        @Part("chat_id") chatId: RequestBody,
+        @Part("chat_id") chatId: ChatId,
         @Part photo: MultipartBody.Part,
         @Part("caption") caption: RequestBody?,
         @Part("parse_mode") parseMode: RequestBody?,
@@ -161,7 +161,7 @@ interface ApiService {
     @Multipart
     @POST("sendAudio")
     fun sendAudio(
-        @Part("chat_id") chatId: RequestBody,
+        @Part("chat_id") chatId: ChatId,
         @Part audio: MultipartBody.Part,
         @Part("duration") duration: RequestBody?,
         @Part("performer") performer: RequestBody?,
@@ -187,7 +187,7 @@ interface ApiService {
     @POST("sendDocument")
     @Multipart
     fun sendDocument(
-        @Part("chat_id") chatId: RequestBody,
+        @Part("chat_id") chatId: ChatId,
         @Part document: MultipartBody.Part,
         @Part("caption") caption: RequestBody?,
         @Part("parse_mode") parseMode: RequestBody?,
@@ -211,7 +211,7 @@ interface ApiService {
     @Multipart
     @POST("sendVideo")
     fun sendVideo(
-        @Part("chat_id") chatId: RequestBody,
+        @Part("chat_id") chatId: ChatId,
         @Part video: MultipartBody.Part,
         @Part("duration") duration: RequestBody?,
         @Part("width") width: RequestBody?,
@@ -239,7 +239,7 @@ interface ApiService {
     @Multipart
     @POST("sendAnimation")
     fun sendAnimation(
-        @Part("chat_id") chatId: RequestBody,
+        @Part("chat_id") chatId: ChatId,
         @Part animation: MultipartBody.Part,
         @Part("duration") duration: RequestBody?,
         @Part("width") width: RequestBody?,
@@ -269,7 +269,7 @@ interface ApiService {
     @Multipart
     @POST("sendVoice")
     fun sendVoice(
-        @Part("chat_id") chatId: RequestBody,
+        @Part("chat_id") chatId: ChatId,
         @Part voice: MultipartBody.Part,
         @Part("caption") caption: RequestBody?,
         @Part("parse_mode") parseMode: RequestBody?,
@@ -297,7 +297,7 @@ interface ApiService {
     @POST("sendVideoNote")
     @Multipart
     fun sendVideoNote(
-        @Part("chat_id") chatId: RequestBody,
+        @Part("chat_id") chatId: ChatId,
         @Part videoNote: MultipartBody.Part,
         @Part("duration") duration: RequestBody?,
         @Part("length") length: RequestBody?,
@@ -481,7 +481,7 @@ interface ApiService {
     @Multipart
     @POST("setChatPhoto")
     fun setChatPhoto(
-        @Part("chat_id") chatId: RequestBody,
+        @Part("chat_id") chatId: ChatId,
         @Part("photo") photo: MultipartBody.Part
     ): Call<Response<Boolean>>
 
@@ -643,7 +643,7 @@ interface ApiService {
     @Multipart
     @POST("sendSticker")
     fun sendSticker(
-        @Part("chat_id") chatId: RequestBody,
+        @Part("chat_id") chatId: ChatId,
         @Part("sticker") sticker: MultipartBody.Part,
         @Part("disable_notification") disableNotification: RequestBody?,
         @Part("reply_to_message_id") replyToMessageId: RequestBody?,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
@@ -199,7 +199,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("sendDocument")
     fun sendDocument(
-        @Field("chat_id") chatId: Long,
+        @Field("chat_id") chatId: ChatId,
         @Field("document") fileId: String,
         @Field("caption") caption: String?,
         @Field("parse_mode") parseMode: ParseMode?,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
@@ -113,7 +113,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("forwardMessage")
     fun forwardMessage(
-        @Field("chat_id") chatId: Long,
+        @Field("chat_id") chatId: ChatId,
         @Field("from_chat_id") fromChatId: Long,
         @Field("disable_notification") disableNotification: Boolean?,
         @Field("message_id") messageId: Long

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
@@ -174,7 +174,7 @@ interface ApiService {
     @FormUrlEncoded
     @POST("sendAudio")
     fun sendAudio(
-        @Field("chat_id") chatId: Long,
+        @Field("chat_id") chatId: ChatId,
         @Field("audio") fileId: String,
         @Field("duration") duration: Int?,
         @Field("performer") performer: String?,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/multipart/MultipartBodyFactory.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/multipart/MultipartBodyFactory.kt
@@ -1,5 +1,6 @@
 package com.github.kotlintelegrambot.network.multipart
 
+import com.github.kotlintelegrambot.entities.ChatId
 import com.github.kotlintelegrambot.entities.TelegramFile
 import com.github.kotlintelegrambot.entities.inputmedia.InputMediaPhoto
 import com.github.kotlintelegrambot.entities.inputmedia.InputMediaVideo
@@ -13,22 +14,12 @@ import java.io.File
 class MultipartBodyFactory(private val gson: Gson) {
 
     fun createForSendMediaGroup(
-        chatId: Long,
+        chatId: ChatId,
         mediaGroup: MediaGroup,
         disableNotification: Boolean? = null,
         replyToMessageId: Long? = null
     ): List<MultipartBody.Part> {
-        val chatIdPart = chatId.toMultipartBodyPart(ApiConstants.CHAT_ID)
-        return createSendMediaGroupMultipartBody(chatIdPart, mediaGroup, disableNotification, replyToMessageId)
-    }
-
-    fun createForSendMediaGroup(
-        chatId: String,
-        mediaGroup: MediaGroup,
-        disableNotification: Boolean? = null,
-        replyToMessageId: Long? = null
-    ): List<MultipartBody.Part> {
-        val chatIdPart = chatId.toMultipartBodyPart(ApiConstants.CHAT_ID)
+        val chatIdPart = chatId.toString().toMultipartBodyPart(ApiConstants.CHAT_ID)
         return createSendMediaGroupMultipartBody(chatIdPart, mediaGroup, disableNotification, replyToMessageId)
     }
 

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/multipart/MultipartBodyFactory.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/multipart/MultipartBodyFactory.kt
@@ -7,6 +7,7 @@ import com.github.kotlintelegrambot.entities.inputmedia.InputMediaVideo
 import com.github.kotlintelegrambot.entities.inputmedia.MediaGroup
 import com.github.kotlintelegrambot.network.ApiConstants
 import com.github.kotlintelegrambot.network.MediaTypeConstants
+import com.github.kotlintelegrambot.network.retrofit.converters.ChatIdConverterFactory
 import com.google.gson.Gson
 import okhttp3.MultipartBody
 import java.io.File
@@ -19,7 +20,8 @@ class MultipartBodyFactory(private val gson: Gson) {
         disableNotification: Boolean? = null,
         replyToMessageId: Long? = null
     ): List<MultipartBody.Part> {
-        val chatIdPart = chatId.toString().toMultipartBodyPart(ApiConstants.CHAT_ID)
+        val chatIdString = ChatIdConverterFactory.chatIdToString(chatId)
+        val chatIdPart = chatIdString.toMultipartBodyPart(ApiConstants.CHAT_ID)
         return createSendMediaGroupMultipartBody(chatIdPart, mediaGroup, disableNotification, replyToMessageId)
     }
 

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/retrofit/converters/ChatIdConverterFactory.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/retrofit/converters/ChatIdConverterFactory.kt
@@ -3,6 +3,8 @@ package com.github.kotlintelegrambot.network.retrofit.converters
 import com.github.kotlintelegrambot.entities.ChatId
 import com.github.kotlintelegrambot.entities.ChatId.ChannelUsername
 import com.github.kotlintelegrambot.entities.ChatId.Id
+import com.github.kotlintelegrambot.network.PLAIN_TEXT_MIME
+import okhttp3.RequestBody
 import retrofit2.Converter
 import retrofit2.Retrofit
 import java.lang.reflect.Type
@@ -12,11 +14,26 @@ class ChatIdConverterFactory : Converter.Factory() {
         if (type !== ChatId::class.java) {
             return null
         }
-        return Converter { chatId: ChatId ->
-            when (chatId) {
-                is Id -> chatId.id.toString()
-                is ChannelUsername -> chatId.username
-            }
+        return Converter { chatId -> chatIdToString(chatId) }
+    }
+
+    override fun requestBodyConverter(
+        type: Type,
+        parameterAnnotations: Array<out Annotation>,
+        methodAnnotations: Array<out Annotation>,
+        retrofit: Retrofit
+    ): Converter<ChatId, RequestBody>? {
+        if (type !== ChatId::class.java) {
+            return null
+        }
+        return Converter { chatId -> RequestBody.create(PLAIN_TEXT_MIME, chatIdToString(chatId)) }
+    }
+
+    companion object {
+        private fun chatIdToString(chatId: ChatId) = when (chatId) {
+            is Id -> chatId.id.toString()
+            is ChannelUsername -> chatId.username
         }
     }
 }
+

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/retrofit/converters/ChatIdConverterFactory.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/retrofit/converters/ChatIdConverterFactory.kt
@@ -30,10 +30,9 @@ class ChatIdConverterFactory : Converter.Factory() {
     }
 
     companion object {
-        private fun chatIdToString(chatId: ChatId) = when (chatId) {
+        fun chatIdToString(chatId: ChatId) = when (chatId) {
             is Id -> chatId.id.toString()
             is ChannelUsername -> chatId.username
         }
     }
 }
-

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/DeleteMessageIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/DeleteMessageIT.kt
@@ -1,7 +1,6 @@
 package com.github.kotlintelegrambot.network.apiclient
 
 import com.github.kotlintelegrambot.entities.ChatId
-import com.github.kotlintelegrambot.entities.ChatId.Companion
 import com.github.kotlintelegrambot.testutils.decode
 import junit.framework.TestCase.assertEquals
 import okhttp3.mockwebserver.MockResponse

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/DeleteMessageIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/DeleteMessageIT.kt
@@ -1,5 +1,7 @@
 package com.github.kotlintelegrambot.network.apiclient
 
+import com.github.kotlintelegrambot.entities.ChatId
+import com.github.kotlintelegrambot.entities.ChatId.Companion
 import com.github.kotlintelegrambot.testutils.decode
 import junit.framework.TestCase.assertEquals
 import okhttp3.mockwebserver.MockResponse
@@ -11,7 +13,7 @@ class DeleteMessageIT : ApiClientIT() {
     fun `deleteMessage with chat id sends correct request`() {
         givenDeleteMessageSuccessfulResponse()
 
-        sut.deleteMessage(ANY_CHAT_ID, ANY_MESSAGE_ID).execute()
+        sut.deleteMessage(ChatId.fromId(ANY_CHAT_ID), ANY_MESSAGE_ID).execute()
 
         val requestBody = mockWebServer.takeRequest().body.readUtf8().decode()
         val expectedRequestBody = "chat_id=$ANY_CHAT_ID&message_id=$ANY_MESSAGE_ID"
@@ -22,7 +24,7 @@ class DeleteMessageIT : ApiClientIT() {
     fun `deleteMessage with channel username sends correct request`() {
         givenDeleteMessageSuccessfulResponse()
 
-        sut.deleteMessage(ANY_CHANNEL_USERNAME, ANY_MESSAGE_ID).execute()
+        sut.deleteMessage(ChatId.fromChannelUsername(ANY_CHANNEL_USERNAME), ANY_MESSAGE_ID).execute()
 
         val requestBody = mockWebServer.takeRequest().body.readUtf8().decode()
         val expectedRequestBody = "chat_id=$ANY_CHANNEL_USERNAME&message_id=$ANY_MESSAGE_ID"
@@ -33,7 +35,7 @@ class DeleteMessageIT : ApiClientIT() {
     fun `deleteMessage response is returned correctly`() {
         givenDeleteMessageSuccessfulResponse()
 
-        val deleteMessageResult = sut.deleteMessage(ANY_CHAT_ID, ANY_MESSAGE_ID).execute()
+        val deleteMessageResult = sut.deleteMessage(ChatId.fromId(ANY_CHAT_ID), ANY_MESSAGE_ID).execute()
 
         assertEquals(true, deleteMessageResult.body()?.result)
     }

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/KickChatMemberIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/KickChatMemberIT.kt
@@ -1,7 +1,6 @@
 package com.github.kotlintelegrambot.network.apiclient
 
 import com.github.kotlintelegrambot.entities.ChatId
-import com.github.kotlintelegrambot.entities.ChatId.Companion
 import com.github.kotlintelegrambot.testutils.decode
 import junit.framework.TestCase.assertEquals
 import okhttp3.mockwebserver.MockResponse

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/KickChatMemberIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/KickChatMemberIT.kt
@@ -1,5 +1,7 @@
 package com.github.kotlintelegrambot.network.apiclient
 
+import com.github.kotlintelegrambot.entities.ChatId
+import com.github.kotlintelegrambot.entities.ChatId.Companion
 import com.github.kotlintelegrambot.testutils.decode
 import junit.framework.TestCase.assertEquals
 import okhttp3.mockwebserver.MockResponse
@@ -11,7 +13,7 @@ class KickChatMemberIT : ApiClientIT() {
     fun `kickChatMember with no until date sends the correct request`() {
         givenKickChatMemberSuccessResponse()
 
-        sut.kickChatMember(ANY_CHAT_ID, ANY_USER_ID).execute()
+        sut.kickChatMember(ChatId.fromId(ANY_CHAT_ID), ANY_USER_ID).execute()
 
         val request = mockWebServer.takeRequest()
         val expectedRequestBody = "chat_id=$ANY_CHAT_ID&user_id=$ANY_USER_ID"
@@ -23,7 +25,7 @@ class KickChatMemberIT : ApiClientIT() {
         givenKickChatMemberSuccessResponse()
 
         sut.kickChatMember(
-            ANY_CHAT_ID,
+            ChatId.fromId(ANY_CHAT_ID),
             ANY_USER_ID,
             ANY_TIMESTAMP
         ).execute()

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/RestrictChatMembersIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/RestrictChatMembersIT.kt
@@ -1,5 +1,6 @@
 package com.github.kotlintelegrambot.network.apiclient
 
+import com.github.kotlintelegrambot.entities.ChatId
 import com.github.kotlintelegrambot.entities.ChatPermissions
 import com.github.kotlintelegrambot.testutils.decode
 import junit.framework.TestCase.assertEquals
@@ -13,7 +14,7 @@ class RestrictChatMembersIT : ApiClientIT() {
         givenRestrictChatMembersSuccessResponse()
 
         sut.restrictChatMember(
-            ANY_CHAT_ID,
+            ChatId.fromId(ANY_CHAT_ID),
             ANY_USER_ID,
             ChatPermissions()
         ).execute()
@@ -28,7 +29,7 @@ class RestrictChatMembersIT : ApiClientIT() {
         givenRestrictChatMembersSuccessResponse()
 
         sut.restrictChatMember(
-            ANY_CHAT_ID,
+            ChatId.fromId(ANY_CHAT_ID),
             ANY_USER_ID,
             ChatPermissions(canSendMessages = false)
         ).execute()
@@ -45,7 +46,7 @@ class RestrictChatMembersIT : ApiClientIT() {
         givenRestrictChatMembersSuccessResponse()
 
         sut.restrictChatMember(
-            ANY_CHAT_ID,
+            ChatId.fromId(ANY_CHAT_ID),
             ANY_USER_ID,
             ChatPermissions(
                 canSendMessages = false,
@@ -68,7 +69,7 @@ class RestrictChatMembersIT : ApiClientIT() {
         givenRestrictChatMembersSuccessResponse()
 
         sut.restrictChatMember(
-            ANY_CHAT_ID,
+            ChatId.fromId(ANY_CHAT_ID),
             ANY_USER_ID,
             ChatPermissions(),
             ANY_TIMESTAMP

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendDiceIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendDiceIT.kt
@@ -1,6 +1,7 @@
 package com.github.kotlintelegrambot.network.apiclient
 
 import com.github.kotlintelegrambot.entities.Chat
+import com.github.kotlintelegrambot.entities.ChatId
 import com.github.kotlintelegrambot.entities.Message
 import com.github.kotlintelegrambot.entities.User
 import com.github.kotlintelegrambot.entities.dice.Dice
@@ -16,7 +17,7 @@ class SendDiceIT : ApiClientIT() {
     fun `sendDice only with mandatory parameters`() {
         givenAnySendDiceResponse()
 
-        sut.sendDice(ANY_CHAT_ID).execute()
+        sut.sendDice(ChatId.fromId(ANY_CHAT_ID)).execute()
 
         val request = mockWebServer.takeRequest()
         val expectedRequestBody = "chat_id=$ANY_CHAT_ID"
@@ -27,7 +28,7 @@ class SendDiceIT : ApiClientIT() {
     fun `sendDice with dice emoji`() {
         givenAnySendDiceResponse()
 
-        sut.sendDice(ANY_CHAT_ID, emoji = DiceEmoji.Dice).execute()
+        sut.sendDice(ChatId.fromId(ANY_CHAT_ID), emoji = DiceEmoji.Dice).execute()
 
         val request = mockWebServer.takeRequest()
         val expectedRequestBody = "chat_id=$ANY_CHAT_ID&emoji=🎲"
@@ -38,7 +39,7 @@ class SendDiceIT : ApiClientIT() {
     fun `sendDice with dartboard emoji`() {
         givenAnySendDiceResponse()
 
-        sut.sendDice(ANY_CHAT_ID, emoji = DiceEmoji.Dartboard).execute()
+        sut.sendDice(ChatId.fromId(ANY_CHAT_ID), emoji = DiceEmoji.Dartboard).execute()
 
         val request = mockWebServer.takeRequest()
         val expectedRequestBody = "chat_id=$ANY_CHAT_ID&emoji=🎯"
@@ -49,7 +50,7 @@ class SendDiceIT : ApiClientIT() {
     fun `sendDice with basketball emoji`() {
         givenAnySendDiceResponse()
 
-        sut.sendDice(ANY_CHAT_ID, emoji = DiceEmoji.Basketball).execute()
+        sut.sendDice(ChatId.fromId(ANY_CHAT_ID), emoji = DiceEmoji.Basketball).execute()
 
         val request = mockWebServer.takeRequest()
         val expectedRequestBody = "chat_id=$ANY_CHAT_ID&emoji=🏀"
@@ -60,7 +61,7 @@ class SendDiceIT : ApiClientIT() {
     fun `sendDice with football emoji`() {
         givenAnySendDiceResponse()
 
-        sut.sendDice(ANY_CHAT_ID, emoji = DiceEmoji.Football).execute()
+        sut.sendDice(ChatId.fromId(ANY_CHAT_ID), emoji = DiceEmoji.Football).execute()
 
         val request = mockWebServer.takeRequest()
         val expectedRequestBody = "chat_id=$ANY_CHAT_ID&emoji=⚽️"
@@ -71,7 +72,7 @@ class SendDiceIT : ApiClientIT() {
     fun `sendDice with slot machine emoji`() {
         givenAnySendDiceResponse()
 
-        sut.sendDice(ANY_CHAT_ID, emoji = DiceEmoji.SlotMachine).execute()
+        sut.sendDice(ChatId.fromId(ANY_CHAT_ID), emoji = DiceEmoji.SlotMachine).execute()
 
         val request = mockWebServer.takeRequest()
         val expectedRequestBody = "chat_id=$ANY_CHAT_ID&emoji=🎰"
@@ -82,7 +83,7 @@ class SendDiceIT : ApiClientIT() {
     fun `sendDice with bowling emoji`() {
         givenAnySendDiceResponse()
 
-        sut.sendDice(ANY_CHAT_ID, emoji = DiceEmoji.Bowling).execute()
+        sut.sendDice(ChatId.fromId(ANY_CHAT_ID), emoji = DiceEmoji.Bowling).execute()
 
         val request = mockWebServer.takeRequest()
         val expectedRequestBody = "chat_id=$ANY_CHAT_ID&emoji=🎳"
@@ -94,7 +95,7 @@ class SendDiceIT : ApiClientIT() {
         givenAnySendDiceResponse()
 
         sut.sendDice(
-            ANY_CHAT_ID,
+            ChatId.fromId(ANY_CHAT_ID),
             emoji = DiceEmoji.Dartboard,
             disableNotification = DISABLE_NOTIFICATION,
             replyToMessageId = ANY_MESSAGE_ID
@@ -112,7 +113,7 @@ class SendDiceIT : ApiClientIT() {
     fun `sendDice response is correctly returned`() {
         givenAnySendDiceResponse()
 
-        val sendDiceResult = sut.sendDice(ANY_CHAT_ID, emoji = DiceEmoji.Dartboard).execute()
+        val sendDiceResult = sut.sendDice(ChatId.fromId(ANY_CHAT_ID), emoji = DiceEmoji.Dartboard).execute()
 
         val expectedMessage = Message(
             messageId = 56,

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendMediaGroupIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendMediaGroupIT.kt
@@ -1,7 +1,6 @@
 package com.github.kotlintelegrambot.network.apiclient
 
 import com.github.kotlintelegrambot.entities.ChatId
-import com.github.kotlintelegrambot.entities.ChatId.Companion
 import com.github.kotlintelegrambot.entities.TelegramFile
 import com.github.kotlintelegrambot.entities.inputmedia.MediaGroup
 import com.github.kotlintelegrambot.entities.inputmedia.anyInputMediaPhoto

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendMediaGroupIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendMediaGroupIT.kt
@@ -1,5 +1,7 @@
 package com.github.kotlintelegrambot.network.apiclient
 
+import com.github.kotlintelegrambot.entities.ChatId
+import com.github.kotlintelegrambot.entities.ChatId.Companion
 import com.github.kotlintelegrambot.entities.TelegramFile
 import com.github.kotlintelegrambot.entities.inputmedia.MediaGroup
 import com.github.kotlintelegrambot.entities.inputmedia.anyInputMediaPhoto
@@ -21,7 +23,7 @@ class SendMediaGroupIT : ApiClientIT() {
             anyInputMediaPhoto(media = TelegramFile.ByFileId(ANY_IMAGE_FILE_ID))
         )
 
-        sut.sendMediaGroup(ANY_CHAT_ID, mediaGroup, DISABLE_NOTIFICATION, REPLY_TO_MESSAGE_ID).execute()
+        sut.sendMediaGroup(ChatId.fromId(ANY_CHAT_ID), mediaGroup, DISABLE_NOTIFICATION, REPLY_TO_MESSAGE_ID).execute()
 
         val request = mockWebServer.takeRequest()
         val multipartBoundary = request.multipartBoundary
@@ -41,7 +43,7 @@ class SendMediaGroupIT : ApiClientIT() {
             anyInputMediaPhoto(media = TelegramFile.ByFileId(ANY_IMAGE_FILE_ID))
         )
 
-        sut.sendMediaGroup(ANY_CHAT_ID, mediaGroup).execute()
+        sut.sendMediaGroup(ChatId.fromId(ANY_CHAT_ID), mediaGroup).execute()
 
         val request = mockWebServer.takeRequest()
         val multipartBoundary = request.multipartBoundary
@@ -61,7 +63,7 @@ class SendMediaGroupIT : ApiClientIT() {
             anyInputMediaPhoto(media = TelegramFile.ByFile(getFileFromResources<SendMediaGroupIT>("image.png")))
         )
 
-        sut.sendMediaGroup(ANY_CHAT_ID, mediaGroup).execute()
+        sut.sendMediaGroup(ChatId.fromId(ANY_CHAT_ID), mediaGroup).execute()
 
         val request = mockWebServer.takeRequest()
         val multipartBoundary = request.multipartBoundary
@@ -84,7 +86,7 @@ class SendMediaGroupIT : ApiClientIT() {
             anyInputMediaPhoto(media = TelegramFile.ByFile(getFileFromResources<SendMediaGroupIT>("image.png")))
         )
 
-        sut.sendMediaGroup(ANY_CHAT_ID, mediaGroup).execute()
+        sut.sendMediaGroup(ChatId.fromId(ANY_CHAT_ID), mediaGroup).execute()
 
         val request = mockWebServer.takeRequest()
         val multipartBoundary = request.multipartBoundary

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendMessageIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendMessageIT.kt
@@ -1,6 +1,8 @@
 package com.github.kotlintelegrambot.network.apiclient
 
 import com.github.kotlintelegrambot.entities.Chat
+import com.github.kotlintelegrambot.entities.ChatId
+import com.github.kotlintelegrambot.entities.ChatId.Companion
 import com.github.kotlintelegrambot.entities.ForceReplyMarkup
 import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
 import com.github.kotlintelegrambot.entities.Message
@@ -18,7 +20,7 @@ class SendMessageIT : ApiClientIT() {
         givenAnySendMessageResponse()
 
         sut.sendMessage(
-            chatId = ANY_CHAT_ID,
+            chatId = ChatId.fromId(ANY_CHAT_ID),
             text = ANY_TEXT,
             parseMode = null,
             disableWebPagePreview = null,
@@ -37,7 +39,7 @@ class SendMessageIT : ApiClientIT() {
         givenAnySendMessageResponse()
 
         sut.sendMessage(
-            channelUsername = ANY_CHANNEL_USERNAME,
+            chatId = ChatId.fromChannelUsername(ANY_CHANNEL_USERNAME),
             text = ANY_TEXT,
             parseMode = null,
             disableWebPagePreview = null,
@@ -56,7 +58,7 @@ class SendMessageIT : ApiClientIT() {
         givenAnySendMessageResponse()
 
         sut.sendMessage(
-            channelUsername = ANY_CHANNEL_USERNAME,
+            chatId = ChatId.fromChannelUsername(ANY_CHANNEL_USERNAME),
             text = ANY_TEXT,
             parseMode = MARKDOWN,
             disableWebPagePreview = false,
@@ -81,7 +83,7 @@ class SendMessageIT : ApiClientIT() {
         givenAnySendMessageResponse()
 
         sut.sendMessage(
-            channelUsername = ANY_CHANNEL_USERNAME,
+            chatId = ChatId.fromChannelUsername(ANY_CHANNEL_USERNAME),
             text = ANY_TEXT,
             parseMode = null,
             disableWebPagePreview = null,
@@ -117,7 +119,7 @@ class SendMessageIT : ApiClientIT() {
         givenAnySendMessageResponse()
 
         val sendMessageResult = sut.sendMessage(
-            chatId = ANY_CHAT_ID,
+            chatId = ChatId.fromId(ANY_CHAT_ID),
             text = ANY_TEXT,
             parseMode = null,
             disableWebPagePreview = null,
@@ -165,7 +167,7 @@ class SendMessageIT : ApiClientIT() {
 
     private companion object {
         const val ANY_CHAT_ID = 235235235L
-        const val ANY_CHANNEL_USERNAME = "testtelegrambotapi"
+        const val ANY_CHANNEL_USERNAME = "@testtelegrambotapi"
         const val ANY_MESSAGE_ID = 35235423L
         const val ANY_TEXT = "Mucho texto"
         const val ANY_URL = "https://www.github.com/vjgarciag96"

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendMessageIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendMessageIT.kt
@@ -2,7 +2,6 @@ package com.github.kotlintelegrambot.network.apiclient
 
 import com.github.kotlintelegrambot.entities.Chat
 import com.github.kotlintelegrambot.entities.ChatId
-import com.github.kotlintelegrambot.entities.ChatId.Companion
 import com.github.kotlintelegrambot.entities.ForceReplyMarkup
 import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
 import com.github.kotlintelegrambot.entities.Message

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendPollIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendPollIT.kt
@@ -2,7 +2,6 @@ package com.github.kotlintelegrambot.network.apiclient
 
 import com.github.kotlintelegrambot.entities.Chat
 import com.github.kotlintelegrambot.entities.ChatId
-import com.github.kotlintelegrambot.entities.ChatId.Companion
 import com.github.kotlintelegrambot.entities.Message
 import com.github.kotlintelegrambot.entities.ParseMode.MARKDOWN
 import com.github.kotlintelegrambot.entities.User

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendPollIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendPollIT.kt
@@ -1,6 +1,8 @@
 package com.github.kotlintelegrambot.network.apiclient
 
 import com.github.kotlintelegrambot.entities.Chat
+import com.github.kotlintelegrambot.entities.ChatId
+import com.github.kotlintelegrambot.entities.ChatId.Companion
 import com.github.kotlintelegrambot.entities.Message
 import com.github.kotlintelegrambot.entities.ParseMode.MARKDOWN
 import com.github.kotlintelegrambot.entities.User
@@ -18,7 +20,7 @@ class SendPollIT : ApiClientIT() {
     fun `sendPoll with chat id and only the mandatory parameters is correctly sent`() {
         givenAnySendPollResponse()
 
-        sut.sendPoll(ANY_CHAT_ID, ANY_QUESTION, ANY_POLL_OPTIONS).execute()
+        sut.sendPoll(ChatId.fromId(ANY_CHAT_ID), ANY_QUESTION, ANY_POLL_OPTIONS).execute()
 
         val request = mockWebServer.takeRequest()
         val expectedRequestBody =
@@ -30,7 +32,7 @@ class SendPollIT : ApiClientIT() {
     fun `sendPoll with channel username and only the mandatory parameters is correctly sent`() {
         givenAnySendPollResponse()
 
-        sut.sendPoll(ANY_CHANNEL_USERNAME, ANY_QUESTION, ANY_POLL_OPTIONS).execute()
+        sut.sendPoll(ChatId.fromChannelUsername(ANY_CHANNEL_USERNAME), ANY_QUESTION, ANY_POLL_OPTIONS).execute()
 
         val request = mockWebServer.takeRequest()
         val expectedRequestBody =
@@ -43,7 +45,7 @@ class SendPollIT : ApiClientIT() {
         givenAnySendPollResponse()
 
         sut.sendPoll(
-            channelUsername = ANY_CHANNEL_USERNAME,
+            chatId = ChatId.fromChannelUsername(ANY_CHANNEL_USERNAME),
             question = ANY_QUESTION,
             options = ANY_POLL_OPTIONS,
             allowsMultipleAnswers = ALLOWS_MULTIPLE_ANSWERS,
@@ -65,7 +67,7 @@ class SendPollIT : ApiClientIT() {
         givenAnySendPollResponse()
 
         sut.sendPoll(
-            chatId = ANY_CHAT_ID,
+            chatId = ChatId.fromId(ANY_CHAT_ID),
             question = ANY_QUESTION,
             options = ANY_POLL_OPTIONS,
             isAnonymous = IS_ANONYMOUS,
@@ -102,7 +104,7 @@ class SendPollIT : ApiClientIT() {
     fun `sendPoll response is returned correctly`() {
         givenAnySendPollResponse()
 
-        val sendPollResult = sut.sendPoll(ANY_CHAT_ID, ANY_QUESTION, ANY_POLL_OPTIONS).execute()
+        val sendPollResult = sut.sendPoll(ChatId.fromId(ANY_CHAT_ID), ANY_QUESTION, ANY_POLL_OPTIONS).execute()
 
         val expectedMessage = Message(
             messageId = 9,

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendVoiceIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendVoiceIT.kt
@@ -1,5 +1,7 @@
 package com.github.kotlintelegrambot.network.apiclient
 
+import com.github.kotlintelegrambot.entities.ChatId
+import com.github.kotlintelegrambot.entities.ChatId.Companion
 import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
 import com.github.kotlintelegrambot.entities.MessageEntity
 import com.github.kotlintelegrambot.entities.MessageEntity.Type.ITALIC
@@ -22,7 +24,7 @@ class SendVoiceIT : ApiClientIT() {
         givenAnySendVoiceResponse()
 
         val sendVoice = sut.sendVoice(
-            ANY_CHAT_ID,
+            ChatId.fromId(ANY_CHAT_ID),
             ANY_VOICE_FILE_ID,
             caption = CAPTION,
             parseMode = MARKDOWN_V2,
@@ -52,7 +54,7 @@ class SendVoiceIT : ApiClientIT() {
         givenAnySendVoiceResponse()
 
         val sendVoice = sut.sendVoice(
-            ANY_CHAT_ID,
+            ChatId.fromId(ANY_CHAT_ID),
             getFileFromResources<SendVoiceIT>(VOICE_FILENAME),
             caption = CAPTION,
             parseMode = MARKDOWN_V2,
@@ -81,7 +83,7 @@ class SendVoiceIT : ApiClientIT() {
         givenAnySendVoiceResponse()
 
         val sendVoice = sut.sendVoice(
-            ANY_CHAT_ID,
+            ChatId.fromId(ANY_CHAT_ID),
             getFileFromResources<SendVoiceIT>("short.ogg").readBytes(),
             caption = CAPTION,
             parseMode = MARKDOWN_V2,

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendVoiceIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendVoiceIT.kt
@@ -1,7 +1,6 @@
 package com.github.kotlintelegrambot.network.apiclient
 
 import com.github.kotlintelegrambot.entities.ChatId
-import com.github.kotlintelegrambot.entities.ChatId.Companion
 import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
 import com.github.kotlintelegrambot.entities.MessageEntity
 import com.github.kotlintelegrambot.entities.MessageEntity.Type.ITALIC

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SetChatAdministratorCustomTitleTest.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SetChatAdministratorCustomTitleTest.kt
@@ -1,7 +1,6 @@
 package com.github.kotlintelegrambot.network.apiclient
 
 import com.github.kotlintelegrambot.entities.ChatId
-import com.github.kotlintelegrambot.entities.ChatId.Companion
 import com.github.kotlintelegrambot.testutils.decode
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SetChatAdministratorCustomTitleTest.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SetChatAdministratorCustomTitleTest.kt
@@ -1,5 +1,7 @@
 package com.github.kotlintelegrambot.network.apiclient
 
+import com.github.kotlintelegrambot.entities.ChatId
+import com.github.kotlintelegrambot.entities.ChatId.Companion
 import com.github.kotlintelegrambot.testutils.decode
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
@@ -15,7 +17,7 @@ class SetChatAdministratorCustomTitleTest : ApiClientIT() {
         givenAnySetChatAdministratorCustomTitleResponse()
 
         sut.setChatAdministratorCustomTitle(
-            chatId = ANY_CHAT_ID,
+            chatId = ChatId.fromId(ANY_CHAT_ID),
             userId = ANY_USER_ID,
             customTitle = ANY_CUSTOM_TITLE
         ).execute()
@@ -32,7 +34,7 @@ class SetChatAdministratorCustomTitleTest : ApiClientIT() {
         givenAnySetChatAdministratorCustomTitleResponse()
 
         sut.setChatAdministratorCustomTitle(
-            channelUsername = ANY_CHANNEL_USERNAME,
+            chatId = ChatId.fromChannelUsername(ANY_CHANNEL_USERNAME),
             userId = ANY_USER_ID,
             customTitle = ANY_CUSTOM_TITLE
         ).execute()
@@ -49,7 +51,7 @@ class SetChatAdministratorCustomTitleTest : ApiClientIT() {
         givenSetChatAdministratorCustomTitleSuccess()
 
         val setChatAdministratorCustomTitleResponse = sut.setChatAdministratorCustomTitle(
-            channelUsername = ANY_CHANNEL_USERNAME,
+            chatId = ChatId.fromChannelUsername(ANY_CHANNEL_USERNAME),
             userId = ANY_USER_ID,
             customTitle = ANY_CUSTOM_TITLE
         ).execute()
@@ -64,7 +66,7 @@ class SetChatAdministratorCustomTitleTest : ApiClientIT() {
         givenSetChatAdministratorCustomTitleError()
 
         val setChatAdministratorCustomTitleResponse = sut.setChatAdministratorCustomTitle(
-            channelUsername = ANY_CHANNEL_USERNAME,
+            chatId = ChatId.fromChannelUsername(ANY_CHANNEL_USERNAME),
             userId = ANY_USER_ID,
             customTitle = ANY_CUSTOM_TITLE
         ).execute()

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SetChatPermissionsIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SetChatPermissionsIT.kt
@@ -1,5 +1,6 @@
 package com.github.kotlintelegrambot.network.apiclient
 
+import com.github.kotlintelegrambot.entities.ChatId
 import com.github.kotlintelegrambot.entities.ChatPermissions
 import com.github.kotlintelegrambot.testutils.decode
 import junit.framework.TestCase
@@ -12,7 +13,7 @@ class SetChatPermissionsIT : ApiClientIT() {
     fun `setChatPermissions with no chat permissions sends the correct request`() {
         givenSetChatPermissionsSuccessResponse()
 
-        sut.setChatPermissions(ANY_CHAT_ID, ChatPermissions()).execute()
+        sut.setChatPermissions(ChatId.fromId(ANY_CHAT_ID), ChatPermissions()).execute()
 
         val request = mockWebServer.takeRequest()
         val expectedRequestBody = "chat_id=1241242&permissions={}"
@@ -24,7 +25,7 @@ class SetChatPermissionsIT : ApiClientIT() {
         givenSetChatPermissionsSuccessResponse()
 
         sut.setChatPermissions(
-            ANY_CHAT_ID,
+            ChatId.fromId(ANY_CHAT_ID),
             ChatPermissions(canSendMessages = false)
         ).execute()
 
@@ -39,7 +40,7 @@ class SetChatPermissionsIT : ApiClientIT() {
         givenSetChatPermissionsSuccessResponse()
 
         sut.setChatPermissions(
-            ANY_CHAT_ID,
+            ChatId.fromId(ANY_CHAT_ID),
             ChatPermissions(
                 canSendMessages = false,
                 canSendPolls = true,


### PR DESCRIPTION
As discussed in https://github.com/kotlin-telegram-bot/kotlin-telegram-bot/issues/128, here I refactored all `chat_id` parameters to support numeric ids as well as channel usernames.
