### PR TITLE
Catch all throwables in handlers execution

### DIFF
--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Dispatcher.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Dispatcher.kt
@@ -69,9 +69,9 @@ class Dispatcher(
                     }
                     try {
                         it.handlerCallback(bot, update)
-                    } catch (exc: Exception) {
+                    } catch (throwable: Throwable) {
                         if (logLevel.shouldLogErrors()) {
-                            exc.printStackTrace()
+                            throwable.printStackTrace()
                         }
                     }
                 }
@@ -82,9 +82,9 @@ class Dispatcher(
         errorHandlers.forEach { handleError ->
             try {
                 handleError(bot, error)
-            } catch (exc: Exception) {
+            } catch (throwable: Throwable) {
                 if (logLevel.shouldLogErrors()) {
-                    exc.printStackTrace()
+                    throwable.printStackTrace()
                 }
             }
         }


### PR DESCRIPTION
We were only catching exceptions, but it might be convenient to also catch errors in order to allow the handlers to recover from them and keep running. I'm not 100% it's a good idea to catch all the errors, but let's do this change and see if we find any problems.