### PR TITLE
Adds sendGame method - Issue #187

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ dependencies {
 2. [Polls](https://github.com/kotlin-telegram-bot/kotlin-telegram-bot/tree/main/docs/polls.md)
 3. [Dice](https://github.com/kotlin-telegram-bot/kotlin-telegram-bot/tree/main/docs/dice.md)
 4. [Logging](https://github.com/kotlin-telegram-bot/kotlin-telegram-bot/tree/main/docs/logging.md)
+5. [Games](https://github.com/kotlin-telegram-bot/kotlin-telegram-bot/tree/main/docs/games.md)
 
 ## Contributing
 

--- a/docs/games.md
+++ b/docs/games.md
@@ -1,0 +1,52 @@
+# Send Games
+
+Your bot can offer users HTML5 games to play solo or to compete against each other in groups and one-on-one chats. 
+Create games via [@BotFather](https://t.me/botfather) using the */newgame* command.
+
+```kotlin
+// List games on command "/list-games"
+val bot = bot {
+    token = BOT_API_TOKEN
+    
+    dispatch {
+        command("list-games") {
+            val gamesNames = listOf("GAME_SHORT_NAME")
+            gamesNames.forEach { bot.sendGame(chatId = ChatId.fromId(message.chat.id), gameShortName = it) }
+        }
+    }
+}
+```
+
+You can further customize the message sent by using the following parameters:
+
+ - **disableNotification:** Sends the message silently. Users will receive a notification with no sound.
+ - **replyToMessageId:** If the message is a reply, ID of the original message
+ - **allowSendingWithoutReply:** Pass True, if the message should be sent even if the specified replied-to message is not found
+ - **replyMarkup:** A JSON-serialized object for an inline keyboard. If empty, one 'Play game_title' button will be shown. If not empty, the first button must launch the game.
+
+```kotlin
+// 'Play game_title' button will be shown
+bot.sendGame(
+        chatId = CHAT_ID,
+        gameShortName = GAME_SHORT_NAME,
+        disableNotification = true,
+        replyToMessageId = MESSAGE_ID,
+        allowSendingWithoutReply = true
+)
+
+// You can customize your own set of buttons, but remember the first one has to be the one to launch the game
+bot.sendGame(
+        chatId = CHAT_ID,
+        gameShortName = GAME_SHORT_NAME,
+        replyMarkup = InlineKeyboardMarkup.createSingleRowKeyboard(
+                InlineKeyboardButton.Url(
+                        text = "Play My Game",
+                        url = GAME_URL
+                ),
+                InlineKeyboardButton.CallbackData(
+                        text = "Button Example",
+                        callbackData = SOME_DATA
+                )
+        )
+)
+```

--- a/telegram/api/telegram.api
+++ b/telegram/api/telegram.api
@@ -83,6 +83,8 @@ public final class com/github/kotlintelegrambot/Bot {
 	public static synthetic fun sendDocument$default (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/ChatId;Ljava/io/File;Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/ParseMode;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Lcom/github/kotlintelegrambot/entities/ReplyMarkup;ILjava/lang/Object;)Lkotlin/Pair;
 	public static synthetic fun sendDocument$default (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/ChatId;Ljava/lang/String;Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/ParseMode;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Lcom/github/kotlintelegrambot/entities/ReplyMarkup;ILjava/lang/Object;)Lkotlin/Pair;
 	public static synthetic fun sendDocument$default (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/ChatId;[BLjava/lang/String;Lcom/github/kotlintelegrambot/entities/ParseMode;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Lcom/github/kotlintelegrambot/entities/ReplyMarkup;Ljava/lang/String;ILjava/lang/Object;)Lkotlin/Pair;
+	public final fun sendGame (Lcom/github/kotlintelegrambot/entities/ChatId;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Lcom/github/kotlintelegrambot/entities/ReplyMarkup;)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
+	public static synthetic fun sendGame$default (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/ChatId;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Lcom/github/kotlintelegrambot/entities/ReplyMarkup;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
 	public final fun sendInvoice (Lcom/github/kotlintelegrambot/entities/ChatId;Lcom/github/kotlintelegrambot/entities/payments/PaymentInvoiceInfo;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Lcom/github/kotlintelegrambot/entities/InlineKeyboardMarkup;)Lkotlin/Pair;
 	public static synthetic fun sendInvoice$default (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/ChatId;Lcom/github/kotlintelegrambot/entities/payments/PaymentInvoiceInfo;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Lcom/github/kotlintelegrambot/entities/InlineKeyboardMarkup;ILjava/lang/Object;)Lkotlin/Pair;
 	public final fun sendLocation (Lcom/github/kotlintelegrambot/entities/ChatId;FFLjava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Lcom/github/kotlintelegrambot/entities/ReplyMarkup;)Lkotlin/Pair;
@@ -456,6 +458,10 @@ public final class com/github/kotlintelegrambot/entities/BotCommand {
 	public final fun getDescription ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/kotlintelegrambot/entities/CallbackGame {
+	public fun <init> ()V
 }
 
 public final class com/github/kotlintelegrambot/entities/CallbackQuery {
@@ -2350,6 +2356,19 @@ public final class com/github/kotlintelegrambot/entities/keyboard/InlineKeyboard
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/github/kotlintelegrambot/entities/keyboard/InlineKeyboardButton$CallbackGameButtonType : com/github/kotlintelegrambot/entities/keyboard/InlineKeyboardButton {
+	public fun <init> (Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/CallbackGame;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/github/kotlintelegrambot/entities/CallbackGame;
+	public final fun copy (Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/CallbackGame;)Lcom/github/kotlintelegrambot/entities/keyboard/InlineKeyboardButton$CallbackGameButtonType;
+	public static synthetic fun copy$default (Lcom/github/kotlintelegrambot/entities/keyboard/InlineKeyboardButton$CallbackGameButtonType;Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/CallbackGame;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/entities/keyboard/InlineKeyboardButton$CallbackGameButtonType;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCallbackGame ()Lcom/github/kotlintelegrambot/entities/CallbackGame;
+	public fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/github/kotlintelegrambot/entities/keyboard/InlineKeyboardButton$Pay : com/github/kotlintelegrambot/entities/keyboard/InlineKeyboardButton {
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -3028,6 +3047,7 @@ public final class com/github/kotlintelegrambot/network/MediaTypeConstants {
 
 public final class com/github/kotlintelegrambot/network/Response {
 	public fun <init> (Ljava/lang/Object;ZLjava/lang/Integer;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Object;ZLjava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Object;
 	public final fun component2 ()Z
 	public final fun component3 ()Ljava/lang/Integer;

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -488,6 +488,37 @@ class Bot private constructor(
         replyMarkup
     ).call()
 
+    /**
+     * Use this method to send a game. On success, the sent Message is returned..
+     *
+     * @param chatId Unique identifier for the target chat or username of the target channel
+     * (in the format @channelusername).
+     * @param gameShortName Short name of the game, serves as the unique identifier for the game.
+     * @param disableNotification Sends the message silently. Users will receive a notification with no sound.
+     * @param replyToMessageId If the message is a reply, ID of the original message.
+     * @param allowSendingWithoutReply Pass True, if the message should be sent even if the specified
+     * replied-to message is not found
+     * @param replyMarkup A JSON-serialized object for an inline keyboard. If empty, one 'Play game_title'
+     * button will be shown. If not empty, the first button must launch the game.
+     *
+     * @return the sent Message.
+     */
+    fun sendGame(
+        chatId: ChatId,
+        gameShortName: String,
+        disableNotification: Boolean? = null,
+        replyToMessageId: Long? = null,
+        allowSendingWithoutReply: Boolean? = null,
+        replyMarkup: ReplyMarkup? = null
+    ): TelegramBotResult<Message> = apiClient.sendGame(
+        chatId,
+        gameShortName,
+        disableNotification,
+        replyToMessageId,
+        allowSendingWithoutReply,
+        replyMarkup
+    )
+
     fun sendAnimation(
         chatId: ChatId,
         animation: SystemFile,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/CallbackGame.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/CallbackGame.kt
@@ -1,0 +1,3 @@
+package com.github.kotlintelegrambot.entities
+
+class CallbackGame()

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/InlineKeyboardMarkup.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/InlineKeyboardMarkup.kt
@@ -14,12 +14,22 @@ data class InlineKeyboardMarkup internal constructor(
 ) : ReplyMarkup {
 
     init {
-        // Buttons of type [Pay] must always be the first button in the first row.
+        validatePriorityButtonsForType<InlineKeyboardButton.Pay>()
+        validatePriorityButtonsForType<InlineKeyboardButton.CallbackGameButtonType>()
+    }
+
+    // Priority buttons must always be the first button in the first row.
+    private inline fun <reified T> validatePriorityButtonsForType() {
         val flattenedButtons = inlineKeyboard.flatten()
-        val payButtons = flattenedButtons.filterIsInstance<InlineKeyboardButton.Pay>()
-        require(payButtons.size <= 1) { "Can't have more than one pay button per inline keyboard" }
-        require(payButtons.size != 1 || flattenedButtons.firstOrNull() is InlineKeyboardButton.Pay) {
-            "Pay buttons must always be the first button in the first row"
+        val filteredButtons = flattenedButtons.filterIsInstance<T>()
+        val typeName = T::class.simpleName
+
+        require(filteredButtons.size <= 1) {
+            "Can't have more than one button of type $typeName per inline keyboard"
+        }
+
+        require(filteredButtons.size != 1 || flattenedButtons.firstOrNull() is T) {
+            "Buttons of type $typeName must always be the first button in the first row"
         }
     }
 

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/keyboard/InlineKeyboardButton.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/keyboard/InlineKeyboardButton.kt
@@ -1,5 +1,6 @@
 package com.github.kotlintelegrambot.entities.keyboard
 
+import com.github.kotlintelegrambot.entities.CallbackGame
 import com.google.gson.annotations.SerializedName
 
 /**
@@ -43,6 +44,15 @@ sealed class InlineKeyboardButton {
     data class SwitchInlineQueryCurrentChat(
         override val text: String,
         @SerializedName("switch_inline_query_current_chat") val switchInlineQueryCurrentChat: String
+    ) : InlineKeyboardButton()
+
+    /**
+     * Description of the game that will be launched when the user presses the button.
+     * NOTE: this type of button must always be the first button in the first row.
+     */
+    data class CallbackGameButtonType(
+        override val text: String,
+        @SerializedName("callback_game") val callbackGame: CallbackGame?
     ) : InlineKeyboardButton()
 
     /**

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -460,6 +460,22 @@ internal class ApiClient(
         )
     }
 
+    fun sendGame(
+        chatId: ChatId,
+        gameShortName: String,
+        disableNotification: Boolean? = null,
+        replyToMessageId: Long? = null,
+        allowSendingWithoutReply: Boolean? = null,
+        replyMarkup: ReplyMarkup? = null
+    ): TelegramBotResult<Message> = service.sendGame(
+        chatId,
+        gameShortName,
+        disableNotification,
+        replyToMessageId,
+        allowSendingWithoutReply,
+        replyMarkup
+    ).runApiOperation()
+
     fun sendAnimation(
         chatId: ChatId,
         animation: SystemFile,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiConstants.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiConstants.kt
@@ -12,6 +12,10 @@ internal object ApiConstants {
         const val MEDIA = "media"
     }
 
+    object SendGame {
+        const val GAME_SHORT_NAME = "game_short_name"
+    }
+
     object SetWebhook {
         const val URL = "url"
         const val CERTIFICATE = "certificate"

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
@@ -245,6 +245,17 @@ internal interface ApiService {
         @Field(ApiConstants.REPLY_MARKUP) replyMarkup: ReplyMarkup? = null
     ): Call<Response<Message>>
 
+    @FormUrlEncoded
+    @POST("sendGame")
+    fun sendGame(
+        @Field(ApiConstants.CHAT_ID) chatId: ChatId,
+        @Field(ApiConstants.SendGame.GAME_SHORT_NAME) gameShortName: String,
+        @Field(ApiConstants.DISABLE_NOTIFICATION) disableNotification: Boolean?,
+        @Field(ApiConstants.REPLY_TO_MESSAGE_ID) replyToMessageId: Long?,
+        @Field(ApiConstants.ALLOW_SENDING_WITHOUT_REPLY) allowSendingWithoutReply: Boolean?,
+        @Field(ApiConstants.REPLY_MARKUP) replyMarkup: ReplyMarkup? = null
+    ): Call<Response<Message>>
+
     @Multipart
     @POST("sendAnimation")
     fun sendAnimation(

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/Response.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/Response.kt
@@ -5,6 +5,6 @@ import com.google.gson.annotations.SerializedName as Name
 data class Response<T>(
     val result: T?,
     val ok: Boolean,
-    @Name("error_code") val errorCode: Int?,
-    @Name("description") val errorDescription: String?
+    @Name("error_code") val errorCode: Int? = null,
+    @Name("description") val errorDescription: String? = null
 )

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/serialization/adapter/InlineKeyboardButtonAdapter.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/serialization/adapter/InlineKeyboardButtonAdapter.kt
@@ -1,7 +1,9 @@
 package com.github.kotlintelegrambot.network.serialization.adapter
 
+import com.github.kotlintelegrambot.entities.CallbackGame
 import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton
 import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton.CallbackData
+import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton.CallbackGameButtonType
 import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton.Pay
 import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton.SwitchInlineQuery
 import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton.SwitchInlineQueryCurrentChat
@@ -20,6 +22,7 @@ internal class InlineKeyboardButtonAdapter : JsonSerializer<InlineKeyboardButton
         val text: String,
         val url: String? = null,
         @SerializedName("callback_data") val callbackData: String? = null,
+        @SerializedName("callback_game") val callbackGame: CallbackGame? = null,
         @SerializedName("switch_inline_query") val switchInlineQuery: String? = null,
         @SerializedName("switch_inline_query_current_chat") val switchInlineQueryCurrentChat: String? = null,
         val pay: Boolean? = null
@@ -34,6 +37,7 @@ internal class InlineKeyboardButtonAdapter : JsonSerializer<InlineKeyboardButton
         is CallbackData -> context.serialize(src, CallbackData::class.java)
         is SwitchInlineQuery -> context.serialize(src, SwitchInlineQuery::class.java)
         is SwitchInlineQueryCurrentChat -> context.serialize(src, SwitchInlineQueryCurrentChat::class.java)
+        is CallbackGameButtonType -> context.serialize(src, CallbackGameButtonType::class.java)
         is Pay -> context.serialize(src, Pay::class.java)
     }
 
@@ -56,6 +60,7 @@ internal class InlineKeyboardButtonAdapter : JsonSerializer<InlineKeyboardButton
                     text,
                     switchInlineQueryCurrentChat
                 )
+                callbackGame != null -> CallbackGameButtonType(text, callbackGame)
                 pay != null -> Pay(text)
                 else -> error("unsupported inline keyboard button $inlineKeyboardButtonDto")
             }

--- a/telegram/src/test/kotlin/Mothers.kt
+++ b/telegram/src/test/kotlin/Mothers.kt
@@ -2,6 +2,7 @@ import com.github.kotlintelegrambot.entities.CallbackQuery
 import com.github.kotlintelegrambot.entities.Chat
 import com.github.kotlintelegrambot.entities.Contact
 import com.github.kotlintelegrambot.entities.Game
+import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
 import com.github.kotlintelegrambot.entities.InlineQuery
 import com.github.kotlintelegrambot.entities.Invoice
 import com.github.kotlintelegrambot.entities.Location
@@ -95,7 +96,8 @@ fun anyMessage(
     invoice: Invoice? = null,
     successfulPayment: SuccessfulPayment? = null,
     dice: Dice? = null,
-    animation: Animation? = null
+    animation: Animation? = null,
+    replyMarkup: InlineKeyboardMarkup? = null
 ): Message = Message(
     messageId = messageId,
     from = from,
@@ -134,7 +136,8 @@ fun anyMessage(
     invoice = invoice,
     successfulPayment = successfulPayment,
     dice = dice,
-    animation = animation
+    animation = animation,
+    replyMarkup = replyMarkup
 )
 
 private const val ANY_CHAT_ID = 243423535L

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/entities/InlineKeyboardButtonMothers.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/entities/InlineKeyboardButtonMothers.kt
@@ -1,0 +1,43 @@
+package com.github.kotlintelegrambot.entities
+
+import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton
+
+private const val ANY_TEXT = "Button text"
+private const val ANY_URL = "https://www.github.com"
+private const val ANY_CALLBACK_DATA = "callback data"
+private const val ANY_INLINE_QUERY = "inline query"
+
+fun anyInlineKeyboardButtonUrl(
+    text: String = ANY_TEXT,
+    url: String = ANY_URL
+): InlineKeyboardButton.Url = InlineKeyboardButton.Url(text, url)
+
+fun anyInlineKeyboardButtonCallbackData(
+    text: String = ANY_TEXT,
+    callbackData: String = ANY_CALLBACK_DATA
+): InlineKeyboardButton.CallbackData = InlineKeyboardButton.CallbackData(text, callbackData)
+
+fun anyInlineKeyboardButtonSwitchInlineQuery(
+    text: String = ANY_TEXT,
+    switchInlineQuery: String = ANY_INLINE_QUERY
+): InlineKeyboardButton.SwitchInlineQuery = InlineKeyboardButton.SwitchInlineQuery(text, switchInlineQuery)
+
+fun anyInlineKeyboardButtonSwitchInlineQueryCurrentChat(
+    text: String = ANY_TEXT,
+    switchInlineQueryCurrentChat: String = ANY_INLINE_QUERY
+): InlineKeyboardButton.SwitchInlineQueryCurrentChat = InlineKeyboardButton.SwitchInlineQueryCurrentChat(
+    text,
+    switchInlineQueryCurrentChat
+)
+
+fun anyInlineKeyboardButtonCallbackGameButtonType(
+    text: String = ANY_TEXT,
+    callbackGame: CallbackGame = CallbackGame()
+): InlineKeyboardButton.CallbackGameButtonType = InlineKeyboardButton.CallbackGameButtonType(
+    text,
+    callbackGame
+)
+
+fun anyInlineKeyboardButtonPay(
+    text: String = ANY_TEXT
+): InlineKeyboardButton.Pay = InlineKeyboardButton.Pay(text)

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/entities/InlineKeyboardMarkupTest.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/entities/InlineKeyboardMarkupTest.kt
@@ -1,6 +1,5 @@
 package com.github.kotlintelegrambot.entities
 
-import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton
 import junit.framework.TestCase.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -12,8 +11,8 @@ class InlineKeyboardMarkupTest {
     fun `can't create an inline keyboard with two pay buttons`() {
         assertThrows<IllegalArgumentException> {
             InlineKeyboardMarkup.create(
-                listOf(InlineKeyboardButton.Pay("1")),
-                listOf(InlineKeyboardButton.Pay("2"))
+                listOf(anyInlineKeyboardButtonPay()),
+                listOf(anyInlineKeyboardButtonPay())
             )
         }
     }
@@ -22,16 +21,36 @@ class InlineKeyboardMarkupTest {
     fun `can't create an inline keyboard with a pay button not first in first row`() {
         assertThrows<IllegalArgumentException> {
             InlineKeyboardMarkup.createSingleRowKeyboard(
-                InlineKeyboardButton.Url("1", "https://www.github.com"),
-                InlineKeyboardButton.Pay("2")
+                anyInlineKeyboardButtonUrl(),
+                anyInlineKeyboardButtonPay()
+            )
+        }
+    }
+
+    @Test
+    fun `can't create an inline keyboard with two CallbackGameButtonType buttons`() {
+        assertThrows<IllegalArgumentException> {
+            InlineKeyboardMarkup.create(
+                listOf(anyInlineKeyboardButtonCallbackGameButtonType()),
+                listOf(anyInlineKeyboardButtonCallbackGameButtonType())
+            )
+        }
+    }
+
+    @Test
+    fun `can't create an inline keyboard with a CallbackGameButtonType button not first in first row`() {
+        assertThrows<IllegalArgumentException> {
+            InlineKeyboardMarkup.createSingleRowKeyboard(
+                anyInlineKeyboardButtonUrl(),
+                anyInlineKeyboardButtonCallbackGameButtonType()
             )
         }
     }
 
     @Test
     fun `create an inline keyboard with pay button first in first row`() {
-        val payButton = InlineKeyboardButton.Pay("1")
-        val urlButton = InlineKeyboardButton.Url("3", "http://noone.com")
+        val payButton = anyInlineKeyboardButtonPay()
+        val urlButton = anyInlineKeyboardButtonUrl()
 
         val inlineKeyboard = InlineKeyboardMarkup.createSingleRowKeyboard(payButton, urlButton)
 
@@ -40,9 +59,20 @@ class InlineKeyboardMarkupTest {
     }
 
     @Test
+    fun `create an inline keyboard with CallbackGameButtonType button first in first row`() {
+        val callbackGameButton = anyInlineKeyboardButtonCallbackGameButtonType()
+        val urlButton = anyInlineKeyboardButtonUrl()
+
+        val inlineKeyboard = InlineKeyboardMarkup.createSingleRowKeyboard(callbackGameButton, urlButton)
+
+        assertEquals(callbackGameButton, inlineKeyboard.inlineKeyboard.flatten().first())
+        assertEquals(urlButton, inlineKeyboard.inlineKeyboard.flatten().last())
+    }
+
+    @Test
     fun `create an inline keyboard with url buttons`() {
-        val urlButton1 = InlineKeyboardButton.Url("3", "http://noone.com")
-        val urlButton2 = InlineKeyboardButton.Url("5", "http://noone.com/2")
+        val urlButton1 = anyInlineKeyboardButtonUrl()
+        val urlButton2 = anyInlineKeyboardButtonUrl()
 
         val inlineKeyboard = InlineKeyboardMarkup.create(listOf(urlButton1), listOf(urlButton2))
 

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendGameIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendGameIT.kt
@@ -1,0 +1,94 @@
+package com.github.kotlintelegrambot.network.apiclient
+
+import anyChat
+import anyGame
+import anyMessage
+import anyPhotoSize
+import anyUser
+import com.github.kotlintelegrambot.entities.CallbackGame
+import com.github.kotlintelegrambot.entities.ChatId
+import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
+import com.github.kotlintelegrambot.entities.Message
+import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton
+import com.github.kotlintelegrambot.network.Response
+import com.github.kotlintelegrambot.testutils.decode
+import com.google.gson.Gson
+import junit.framework.TestCase.assertEquals
+import okhttp3.mockwebserver.MockResponse
+import org.junit.jupiter.api.Test
+
+class SendGameIT : ApiClientIT() {
+
+    @Test
+    fun `#sendGame with all parameters creates request correctly`() {
+        givenAnySendGameResponse()
+
+        sut.sendGame(
+            chatId = ChatId.fromId(ANY_CHAT_ID),
+            gameShortName = ANY_GAME_NAME,
+            disableNotification = true,
+            replyToMessageId = REPLY_TO_MESSAGE_ID,
+            allowSendingWithoutReply = true,
+            replyMarkup = REPLY_MARKUP_WITH_1ST_BUTTON_LAUNCH
+        )
+
+        val request = mockWebServer.takeRequest()
+        val expectedRequestBody = "chat_id=$ANY_CHAT_ID" +
+            "&game_short_name=$ANY_GAME_NAME" +
+            "&disable_notification=true" +
+            "&reply_to_message_id=$REPLY_TO_MESSAGE_ID" +
+            "&allow_sending_without_reply=true" +
+            "&reply_markup=${gson.toJson(REPLY_MARKUP_WITH_1ST_BUTTON_LAUNCH)}"
+
+        assertEquals(expectedRequestBody, request.body.readUtf8().decode())
+    }
+
+    @Test
+    fun `#sendGame with required parameters returns response correctly`() {
+        givenAnySendGameResponse()
+
+        val sendGameResponse = sut.sendGame(
+            chatId = ChatId.fromId(ANY_CHAT_ID),
+            gameShortName = ANY_GAME_NAME
+        )
+
+        assertEquals(anyGameMessage.toString().trim(), sendGameResponse.get().toString().trim())
+    }
+
+    private fun givenAnySendGameResponse() {
+        val sendGameResponse = Response<Message>(
+            ok = true,
+            result = anyGameMessage
+        )
+
+        val mockedResponse = MockResponse()
+            .setResponseCode(200)
+            .setBody(gson.toJson(sendGameResponse))
+        mockWebServer.enqueue(mockedResponse)
+    }
+
+    private companion object {
+        val gson = Gson()
+        const val ANY_CHAT_ID = 2351353153L
+        const val ANY_GAME_NAME = "game_name"
+        const val REPLY_TO_MESSAGE_ID = 32235235L
+
+        val REPLY_MARKUP_WITH_1ST_BUTTON_LAUNCH = InlineKeyboardMarkup.createSingleButton(
+            InlineKeyboardButton.CallbackGameButtonType(
+                text = "Play gameTest",
+                callbackGame = CallbackGame()
+            )
+        )
+
+        val anyGameMessage = anyMessage(
+            from = anyUser(),
+            chat = anyChat(
+                id = ANY_CHAT_ID
+            ),
+            game = anyGame(
+                photos = listOf(anyPhotoSize(), anyPhotoSize())
+            ),
+            replyMarkup = REPLY_MARKUP_WITH_1ST_BUTTON_LAUNCH
+        )
+    }
+}


### PR DESCRIPTION
 Adds sendGame support - Issue #187 

- creates junit tests for the new method
 - updates documentation
 - adds the entity CallbackGame which is used by the telegram api as a placeholder
and as of now holds no information
 - adds support for the inlineKeyboardButton that is supposed to be of CallbackGame type
 - adds the field replyMarkup to the Message example factory(Mothers.kt) in the tests
 - sets the default values of errorCode and errorDescription in Response Serialization data class
to null so it is not required to pass them when instatiating

Also ktlint changed a few imports in Mother.kt.

Please let me know if you have any questions, suggestions or changes. :)