### PR TITLE
Add replyToMessage extension to all applicable HandlerEnvironments.

### DIFF
--- a/telegram/api/telegram.api
+++ b/telegram/api/telegram.api
@@ -240,7 +240,7 @@ public final class com/github/kotlintelegrambot/dispatcher/handlers/ChannelHandl
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/github/kotlintelegrambot/dispatcher/handlers/CommandHandlerEnvironment {
+public final class com/github/kotlintelegrambot/dispatcher/handlers/CommandHandlerEnvironment : com/github/kotlintelegrambot/dispatcher/handlers/IMessageHandlerEnvironment {
 	public final fun component1 ()Lcom/github/kotlintelegrambot/Bot;
 	public final fun component2 ()Lcom/github/kotlintelegrambot/entities/Update;
 	public final fun component3 ()Lcom/github/kotlintelegrambot/entities/Message;
@@ -249,14 +249,14 @@ public final class com/github/kotlintelegrambot/dispatcher/handlers/CommandHandl
 	public static synthetic fun copy$default (Lcom/github/kotlintelegrambot/dispatcher/handlers/CommandHandlerEnvironment;Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/Message;Ljava/util/List;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/dispatcher/handlers/CommandHandlerEnvironment;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getArgs ()Ljava/util/List;
-	public final fun getBot ()Lcom/github/kotlintelegrambot/Bot;
-	public final fun getMessage ()Lcom/github/kotlintelegrambot/entities/Message;
-	public final fun getUpdate ()Lcom/github/kotlintelegrambot/entities/Update;
+	public fun getBot ()Lcom/github/kotlintelegrambot/Bot;
+	public fun getMessage ()Lcom/github/kotlintelegrambot/entities/Message;
+	public fun getUpdate ()Lcom/github/kotlintelegrambot/entities/Update;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/github/kotlintelegrambot/dispatcher/handlers/ContactHandlerEnvironment {
+public final class com/github/kotlintelegrambot/dispatcher/handlers/ContactHandlerEnvironment : com/github/kotlintelegrambot/dispatcher/handlers/IMessageHandlerEnvironment {
 	public fun <init> (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Contact;)V
 	public final fun component1 ()Lcom/github/kotlintelegrambot/Bot;
 	public final fun component2 ()Lcom/github/kotlintelegrambot/entities/Update;
@@ -265,15 +265,15 @@ public final class com/github/kotlintelegrambot/dispatcher/handlers/ContactHandl
 	public final fun copy (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Contact;)Lcom/github/kotlintelegrambot/dispatcher/handlers/ContactHandlerEnvironment;
 	public static synthetic fun copy$default (Lcom/github/kotlintelegrambot/dispatcher/handlers/ContactHandlerEnvironment;Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Contact;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/dispatcher/handlers/ContactHandlerEnvironment;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBot ()Lcom/github/kotlintelegrambot/Bot;
+	public fun getBot ()Lcom/github/kotlintelegrambot/Bot;
 	public final fun getContact ()Lcom/github/kotlintelegrambot/entities/Contact;
-	public final fun getMessage ()Lcom/github/kotlintelegrambot/entities/Message;
-	public final fun getUpdate ()Lcom/github/kotlintelegrambot/entities/Update;
+	public fun getMessage ()Lcom/github/kotlintelegrambot/entities/Message;
+	public fun getUpdate ()Lcom/github/kotlintelegrambot/entities/Update;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/github/kotlintelegrambot/dispatcher/handlers/DiceHandlerEnvironment {
+public final class com/github/kotlintelegrambot/dispatcher/handlers/DiceHandlerEnvironment : com/github/kotlintelegrambot/dispatcher/handlers/IMessageHandlerEnvironment {
 	public fun <init> (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/dice/Dice;)V
 	public final fun component1 ()Lcom/github/kotlintelegrambot/Bot;
 	public final fun component2 ()Lcom/github/kotlintelegrambot/entities/Update;
@@ -282,10 +282,10 @@ public final class com/github/kotlintelegrambot/dispatcher/handlers/DiceHandlerE
 	public final fun copy (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/dice/Dice;)Lcom/github/kotlintelegrambot/dispatcher/handlers/DiceHandlerEnvironment;
 	public static synthetic fun copy$default (Lcom/github/kotlintelegrambot/dispatcher/handlers/DiceHandlerEnvironment;Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/dice/Dice;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/dispatcher/handlers/DiceHandlerEnvironment;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBot ()Lcom/github/kotlintelegrambot/Bot;
+	public fun getBot ()Lcom/github/kotlintelegrambot/Bot;
 	public final fun getDice ()Lcom/github/kotlintelegrambot/entities/dice/Dice;
-	public final fun getMessage ()Lcom/github/kotlintelegrambot/entities/Message;
-	public final fun getUpdate ()Lcom/github/kotlintelegrambot/entities/Update;
+	public fun getMessage ()Lcom/github/kotlintelegrambot/entities/Message;
+	public fun getUpdate ()Lcom/github/kotlintelegrambot/entities/Update;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -313,6 +313,12 @@ public abstract interface class com/github/kotlintelegrambot/dispatcher/handlers
 	public abstract fun handleUpdate (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;)V
 }
 
+public abstract interface class com/github/kotlintelegrambot/dispatcher/handlers/IMessageHandlerEnvironment {
+	public abstract fun getBot ()Lcom/github/kotlintelegrambot/Bot;
+	public abstract fun getMessage ()Lcom/github/kotlintelegrambot/entities/Message;
+	public abstract fun getUpdate ()Lcom/github/kotlintelegrambot/entities/Update;
+}
+
 public final class com/github/kotlintelegrambot/dispatcher/handlers/InlineQueryHandlerEnvironment {
 	public fun <init> (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/InlineQuery;)V
 	public final fun component1 ()Lcom/github/kotlintelegrambot/Bot;
@@ -328,7 +334,7 @@ public final class com/github/kotlintelegrambot/dispatcher/handlers/InlineQueryH
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/github/kotlintelegrambot/dispatcher/handlers/LocationHandlerEnvironment {
+public final class com/github/kotlintelegrambot/dispatcher/handlers/LocationHandlerEnvironment : com/github/kotlintelegrambot/dispatcher/handlers/IMessageHandlerEnvironment {
 	public fun <init> (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Location;)V
 	public final fun component1 ()Lcom/github/kotlintelegrambot/Bot;
 	public final fun component2 ()Lcom/github/kotlintelegrambot/entities/Update;
@@ -337,15 +343,15 @@ public final class com/github/kotlintelegrambot/dispatcher/handlers/LocationHand
 	public final fun copy (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Location;)Lcom/github/kotlintelegrambot/dispatcher/handlers/LocationHandlerEnvironment;
 	public static synthetic fun copy$default (Lcom/github/kotlintelegrambot/dispatcher/handlers/LocationHandlerEnvironment;Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Location;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/dispatcher/handlers/LocationHandlerEnvironment;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBot ()Lcom/github/kotlintelegrambot/Bot;
+	public fun getBot ()Lcom/github/kotlintelegrambot/Bot;
 	public final fun getLocation ()Lcom/github/kotlintelegrambot/entities/Location;
-	public final fun getMessage ()Lcom/github/kotlintelegrambot/entities/Message;
-	public final fun getUpdate ()Lcom/github/kotlintelegrambot/entities/Update;
+	public fun getMessage ()Lcom/github/kotlintelegrambot/entities/Message;
+	public fun getUpdate ()Lcom/github/kotlintelegrambot/entities/Update;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/github/kotlintelegrambot/dispatcher/handlers/MessageHandlerEnvironment {
+public final class com/github/kotlintelegrambot/dispatcher/handlers/MessageHandlerEnvironment : com/github/kotlintelegrambot/dispatcher/handlers/IMessageHandlerEnvironment {
 	public fun <init> (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/Message;)V
 	public final fun component1 ()Lcom/github/kotlintelegrambot/Bot;
 	public final fun component2 ()Lcom/github/kotlintelegrambot/entities/Update;
@@ -353,14 +359,18 @@ public final class com/github/kotlintelegrambot/dispatcher/handlers/MessageHandl
 	public final fun copy (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/Message;)Lcom/github/kotlintelegrambot/dispatcher/handlers/MessageHandlerEnvironment;
 	public static synthetic fun copy$default (Lcom/github/kotlintelegrambot/dispatcher/handlers/MessageHandlerEnvironment;Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/Message;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/dispatcher/handlers/MessageHandlerEnvironment;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBot ()Lcom/github/kotlintelegrambot/Bot;
-	public final fun getMessage ()Lcom/github/kotlintelegrambot/entities/Message;
-	public final fun getUpdate ()Lcom/github/kotlintelegrambot/entities/Update;
+	public fun getBot ()Lcom/github/kotlintelegrambot/Bot;
+	public fun getMessage ()Lcom/github/kotlintelegrambot/entities/Message;
+	public fun getUpdate ()Lcom/github/kotlintelegrambot/entities/Update;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/github/kotlintelegrambot/dispatcher/handlers/NewChatMembersHandlerEnvironment {
+public final class com/github/kotlintelegrambot/dispatcher/handlers/MessageHandlerEnvironmentExtensionsKt {
+	public static final fun replyToMessage (Lcom/github/kotlintelegrambot/dispatcher/handlers/IMessageHandlerEnvironment;Ljava/lang/String;)V
+}
+
+public final class com/github/kotlintelegrambot/dispatcher/handlers/NewChatMembersHandlerEnvironment : com/github/kotlintelegrambot/dispatcher/handlers/IMessageHandlerEnvironment {
 	public fun <init> (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/Message;Ljava/util/List;)V
 	public final fun component1 ()Lcom/github/kotlintelegrambot/Bot;
 	public final fun component2 ()Lcom/github/kotlintelegrambot/entities/Update;
@@ -369,10 +379,10 @@ public final class com/github/kotlintelegrambot/dispatcher/handlers/NewChatMembe
 	public final fun copy (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/Message;Ljava/util/List;)Lcom/github/kotlintelegrambot/dispatcher/handlers/NewChatMembersHandlerEnvironment;
 	public static synthetic fun copy$default (Lcom/github/kotlintelegrambot/dispatcher/handlers/NewChatMembersHandlerEnvironment;Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/Message;Ljava/util/List;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/dispatcher/handlers/NewChatMembersHandlerEnvironment;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBot ()Lcom/github/kotlintelegrambot/Bot;
-	public final fun getMessage ()Lcom/github/kotlintelegrambot/entities/Message;
+	public fun getBot ()Lcom/github/kotlintelegrambot/Bot;
+	public fun getMessage ()Lcom/github/kotlintelegrambot/entities/Message;
 	public final fun getNewChatMembers ()Ljava/util/List;
-	public final fun getUpdate ()Lcom/github/kotlintelegrambot/entities/Update;
+	public fun getUpdate ()Lcom/github/kotlintelegrambot/entities/Update;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -407,7 +417,7 @@ public final class com/github/kotlintelegrambot/dispatcher/handlers/PreCheckoutQ
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/github/kotlintelegrambot/dispatcher/handlers/TextHandlerEnvironment {
+public final class com/github/kotlintelegrambot/dispatcher/handlers/TextHandlerEnvironment : com/github/kotlintelegrambot/dispatcher/handlers/IMessageHandlerEnvironment {
 	public fun <init> (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/Message;Ljava/lang/String;)V
 	public final fun component1 ()Lcom/github/kotlintelegrambot/Bot;
 	public final fun component2 ()Lcom/github/kotlintelegrambot/entities/Update;
@@ -416,10 +426,10 @@ public final class com/github/kotlintelegrambot/dispatcher/handlers/TextHandlerE
 	public final fun copy (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/Message;Ljava/lang/String;)Lcom/github/kotlintelegrambot/dispatcher/handlers/TextHandlerEnvironment;
 	public static synthetic fun copy$default (Lcom/github/kotlintelegrambot/dispatcher/handlers/TextHandlerEnvironment;Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/Message;Ljava/lang/String;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/dispatcher/handlers/TextHandlerEnvironment;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBot ()Lcom/github/kotlintelegrambot/Bot;
-	public final fun getMessage ()Lcom/github/kotlintelegrambot/entities/Message;
+	public fun getBot ()Lcom/github/kotlintelegrambot/Bot;
+	public fun getMessage ()Lcom/github/kotlintelegrambot/entities/Message;
 	public final fun getText ()Ljava/lang/String;
-	public final fun getUpdate ()Lcom/github/kotlintelegrambot/entities/Update;
+	public fun getUpdate ()Lcom/github/kotlintelegrambot/entities/Update;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/CommandHandler.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/CommandHandler.kt
@@ -5,11 +5,11 @@ import com.github.kotlintelegrambot.entities.Message
 import com.github.kotlintelegrambot.entities.Update
 
 data class CommandHandlerEnvironment internal constructor(
-    val bot: Bot,
-    val update: Update,
-    val message: Message,
+    override val bot: Bot,
+    override val update: Update,
+    override val message: Message,
     val args: List<String>
-)
+): IMessageHandlerEnvironment
 
 internal class CommandHandler(
     private val command: String,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/CommandHandler.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/CommandHandler.kt
@@ -9,7 +9,7 @@ data class CommandHandlerEnvironment internal constructor(
     override val update: Update,
     override val message: Message,
     val args: List<String>
-): IMessageHandlerEnvironment
+) : IMessageHandlerEnvironment
 
 internal class CommandHandler(
     private val command: String,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/ContactHandler.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/ContactHandler.kt
@@ -6,11 +6,11 @@ import com.github.kotlintelegrambot.entities.Message
 import com.github.kotlintelegrambot.entities.Update
 
 data class ContactHandlerEnvironment(
-    val bot: Bot,
-    val update: Update,
-    val message: Message,
+    override val bot: Bot,
+    override val update: Update,
+    override val message: Message,
     val contact: Contact
-)
+): IMessageHandlerEnvironment
 
 internal class ContactHandler(
     private val handleContact: HandleContact

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/ContactHandler.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/ContactHandler.kt
@@ -10,7 +10,7 @@ data class ContactHandlerEnvironment(
     override val update: Update,
     override val message: Message,
     val contact: Contact
-): IMessageHandlerEnvironment
+) : IMessageHandlerEnvironment
 
 internal class ContactHandler(
     private val handleContact: HandleContact

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/DiceHandler.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/DiceHandler.kt
@@ -10,7 +10,7 @@ data class DiceHandlerEnvironment(
     override val update: Update,
     override val message: Message,
     val dice: Dice
-): IMessageHandlerEnvironment
+) : IMessageHandlerEnvironment
 
 internal class DiceHandler(
     private val handleDice: HandleDice

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/DiceHandler.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/DiceHandler.kt
@@ -6,11 +6,11 @@ import com.github.kotlintelegrambot.entities.Update
 import com.github.kotlintelegrambot.entities.dice.Dice
 
 data class DiceHandlerEnvironment(
-    val bot: Bot,
-    val update: Update,
-    val message: Message,
+    override val bot: Bot,
+    override val update: Update,
+    override val message: Message,
     val dice: Dice
-)
+): IMessageHandlerEnvironment
 
 internal class DiceHandler(
     private val handleDice: HandleDice

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/LocationHandler.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/LocationHandler.kt
@@ -6,11 +6,11 @@ import com.github.kotlintelegrambot.entities.Message
 import com.github.kotlintelegrambot.entities.Update
 
 data class LocationHandlerEnvironment(
-    val bot: Bot,
-    val update: Update,
-    val message: Message,
+    override val bot: Bot,
+    override val update: Update,
+    override val message: Message,
     val location: Location
-)
+): IMessageHandlerEnvironment
 
 internal class LocationHandler(
     private val handleLocation: HandleLocation

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/LocationHandler.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/LocationHandler.kt
@@ -10,7 +10,7 @@ data class LocationHandlerEnvironment(
     override val update: Update,
     override val message: Message,
     val location: Location
-): IMessageHandlerEnvironment
+) : IMessageHandlerEnvironment
 
 internal class LocationHandler(
     private val handleLocation: HandleLocation

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/MessageHandler.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/MessageHandler.kt
@@ -5,11 +5,17 @@ import com.github.kotlintelegrambot.entities.Message
 import com.github.kotlintelegrambot.entities.Update
 import com.github.kotlintelegrambot.extensions.filters.Filter
 
-data class MessageHandlerEnvironment(
-    val bot: Bot,
-    val update: Update,
+interface IMessageHandlerEnvironment {
+    val bot: Bot
+    val update: Update
     val message: Message
-)
+}
+
+data class MessageHandlerEnvironment(
+    override val bot: Bot,
+    override val update: Update,
+    override val message: Message
+): IMessageHandlerEnvironment
 
 internal class MessageHandler(
     private val filter: Filter,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/MessageHandler.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/MessageHandler.kt
@@ -15,7 +15,7 @@ data class MessageHandlerEnvironment(
     override val bot: Bot,
     override val update: Update,
     override val message: Message
-): IMessageHandlerEnvironment
+) : IMessageHandlerEnvironment
 
 internal class MessageHandler(
     private val filter: Filter,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/MessageHandlerEnvironmentExtensions.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/MessageHandlerEnvironmentExtensions.kt
@@ -1,0 +1,7 @@
+package com.github.kotlintelegrambot.dispatcher.handlers
+
+import com.github.kotlintelegrambot.entities.ChatId
+
+fun IMessageHandlerEnvironment.replyToMessage(text: String) {
+    bot.sendMessage(ChatId.fromId(message.chat.id), text, replyToMessageId = message.messageId)
+}

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/NewChatMembersHandler.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/NewChatMembersHandler.kt
@@ -6,11 +6,11 @@ import com.github.kotlintelegrambot.entities.Update
 import com.github.kotlintelegrambot.entities.User
 
 data class NewChatMembersHandlerEnvironment(
-    val bot: Bot,
-    val update: Update,
-    val message: Message,
+    override val bot: Bot,
+    override val update: Update,
+    override val message: Message,
     val newChatMembers: List<User>
-)
+): IMessageHandlerEnvironment
 
 internal class NewChatMembersHandler(
     private val handleNewChatMembers: HandleNewChatMembers

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/NewChatMembersHandler.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/NewChatMembersHandler.kt
@@ -10,7 +10,7 @@ data class NewChatMembersHandlerEnvironment(
     override val update: Update,
     override val message: Message,
     val newChatMembers: List<User>
-): IMessageHandlerEnvironment
+) : IMessageHandlerEnvironment
 
 internal class NewChatMembersHandler(
     private val handleNewChatMembers: HandleNewChatMembers

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/TextHandler.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/TextHandler.kt
@@ -5,11 +5,11 @@ import com.github.kotlintelegrambot.entities.Message
 import com.github.kotlintelegrambot.entities.Update
 
 data class TextHandlerEnvironment(
-    val bot: Bot,
-    val update: Update,
-    val message: Message,
+    override val bot: Bot,
+    override val update: Update,
+    override val message: Message,
     val text: String
-)
+): IMessageHandlerEnvironment
 
 internal class TextHandler(
     private val text: String? = null,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/TextHandler.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/TextHandler.kt
@@ -9,7 +9,7 @@ data class TextHandlerEnvironment(
     override val update: Update,
     override val message: Message,
     val text: String
-): IMessageHandlerEnvironment
+) : IMessageHandlerEnvironment
 
 internal class TextHandler(
     private val text: String? = null,


### PR DESCRIPTION
In my own code I found a simple replyToMessage extension very handy in the HandlerEnvironments. However I have to create one for every HandlerEnvironment. I think to generalize the Environments with some Interfaces would solve that problem.

I'm not sure if the filenames and locations that I chose here are really the most suitable ones though. I don't know the project very well so far and I'm rather new to Kotlin too. I would love some feedback on that so I can improve.

This is the first time I really try to contribute on Github. If I make any mistakes in the procedure please tell me :)