### PR TITLE
Rename kickChatMember to banChatMember

### DIFF
--- a/telegram/api/telegram.api
+++ b/telegram/api/telegram.api
@@ -12,6 +12,8 @@ public final class com/github/kotlintelegrambot/Bot {
 	public static synthetic fun answerPreCheckoutQuery$default (Lcom/github/kotlintelegrambot/Bot;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
 	public final fun answerShippingQuery (Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
 	public static synthetic fun answerShippingQuery$default (Lcom/github/kotlintelegrambot/Bot;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
+	public final fun banChatMember (Lcom/github/kotlintelegrambot/entities/ChatId;JLjava/lang/Long;)Lkotlin/Pair;
+	public static synthetic fun banChatMember$default (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/ChatId;JLjava/lang/Long;ILjava/lang/Object;)Lkotlin/Pair;
 	public final fun copyMessage (Lcom/github/kotlintelegrambot/entities/ChatId;Lcom/github/kotlintelegrambot/entities/ChatId;JLjava/lang/String;Lcom/github/kotlintelegrambot/entities/ParseMode;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Lcom/github/kotlintelegrambot/entities/ReplyMarkup;)Lkotlin/Pair;
 	public static synthetic fun copyMessage$default (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/ChatId;Lcom/github/kotlintelegrambot/entities/ChatId;JLjava/lang/String;Lcom/github/kotlintelegrambot/entities/ParseMode;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Lcom/github/kotlintelegrambot/entities/ReplyMarkup;ILjava/lang/Object;)Lkotlin/Pair;
 	public final fun createNewStickerSet (JLjava/lang/String;Ljava/lang/String;Ljava/io/File;Ljava/lang/String;Ljava/lang/Boolean;Lcom/github/kotlintelegrambot/entities/stickers/MaskPosition;)Lkotlin/Pair;
@@ -51,8 +53,6 @@ public final class com/github/kotlintelegrambot/Bot {
 	public final fun getUserProfilePhotos (JLjava/lang/Long;Ljava/lang/Integer;)Lkotlin/Pair;
 	public static synthetic fun getUserProfilePhotos$default (Lcom/github/kotlintelegrambot/Bot;JLjava/lang/Long;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlin/Pair;
 	public final fun getWebhookInfo ()Lkotlin/Pair;
-	public final fun kickChatMember (Lcom/github/kotlintelegrambot/entities/ChatId;JLjava/lang/Long;)Lkotlin/Pair;
-	public static synthetic fun kickChatMember$default (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/ChatId;JLjava/lang/Long;ILjava/lang/Object;)Lkotlin/Pair;
 	public final fun leaveChat (Lcom/github/kotlintelegrambot/entities/ChatId;)Lkotlin/Pair;
 	public final fun logOut ()Lkotlin/Pair;
 	public final fun pinChatMessage (Lcom/github/kotlintelegrambot/entities/ChatId;JLjava/lang/Boolean;)Lkotlin/Pair;

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -1154,11 +1154,11 @@ class Bot private constructor(
         }
     }
 
-    fun kickChatMember(
+    fun banChatMember(
         chatId: ChatId,
         userId: Long,
         untilDate: Long? = null // unix time - https://en.wikipedia.org/wiki/Unix_time
-    ) = apiClient.kickChatMember(chatId, userId, untilDate).call()
+    ) = apiClient.banChatMember(chatId, userId, untilDate).call()
 
     /**
      * Use this method to unban a previously kicked user in a supergroup or channel. The user will

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -778,9 +778,9 @@ internal class ApiClient(
         return service.downloadFile("${apiUrl}file/bot$token/$filePath")
     }
 
-    fun kickChatMember(chatId: ChatId, userId: Long, untilDate: Long? = null): Call<Response<Boolean>> {
+    fun banChatMember(chatId: ChatId, userId: Long, untilDate: Long? = null): Call<Response<Boolean>> {
 
-        return service.kickChatMember(chatId, userId, untilDate)
+        return service.banChatMember(chatId, userId, untilDate)
     }
 
     fun unbanChatMember(

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
@@ -460,8 +460,8 @@ internal interface ApiService {
     ): Call<ResponseBody>
 
     @FormUrlEncoded
-    @POST("kickChatMember")
-    fun kickChatMember(
+    @POST("banChatMember")
+    fun banChatMember(
         @Field(ApiConstants.CHAT_ID) chatId: ChatId,
         @Field(ApiConstants.USER_ID) userId: Long,
         @Field("until_date") untilDate: Long?

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/BanChatMemberIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/BanChatMemberIT.kt
@@ -6,13 +6,13 @@ import junit.framework.TestCase.assertEquals
 import okhttp3.mockwebserver.MockResponse
 import org.junit.jupiter.api.Test
 
-class KickChatMemberIT : ApiClientIT() {
+class BanChatMemberIT : ApiClientIT() {
 
     @Test
-    fun `kickChatMember with no until date sends the correct request`() {
-        givenKickChatMemberSuccessResponse()
+    fun `banChatMember with no until date sends the correct request`() {
+        givenBanChatMemberSuccessResponse()
 
-        sut.kickChatMember(ChatId.fromId(ANY_CHAT_ID), ANY_USER_ID).execute()
+        sut.banChatMember(ChatId.fromId(ANY_CHAT_ID), ANY_USER_ID).execute()
 
         val request = mockWebServer.takeRequest()
         val expectedRequestBody = "chat_id=$ANY_CHAT_ID&user_id=$ANY_USER_ID"
@@ -20,10 +20,10 @@ class KickChatMemberIT : ApiClientIT() {
     }
 
     @Test
-    fun `kickChatMember with until date sends the correct request`() {
-        givenKickChatMemberSuccessResponse()
+    fun `banChatMember with until date sends the correct request`() {
+        givenBanChatMemberSuccessResponse()
 
-        sut.kickChatMember(
+        sut.banChatMember(
             ChatId.fromId(ANY_CHAT_ID),
             ANY_USER_ID,
             ANY_TIMESTAMP
@@ -34,8 +34,8 @@ class KickChatMemberIT : ApiClientIT() {
         assertEquals(expectedRequestBody, request.body.readUtf8().decode())
     }
 
-    private fun givenKickChatMemberSuccessResponse() {
-        val kickChatMemberResponseBody = """
+    private fun givenBanChatMemberSuccessResponse() {
+        val banChatMemberResponseBody = """
             {
                 "ok": true,
                 "result": true 
@@ -43,7 +43,7 @@ class KickChatMemberIT : ApiClientIT() {
         """.trimIndent()
         val mockedSuccessResponse = MockResponse()
             .setResponseCode(200)
-            .setBody(kickChatMemberResponseBody)
+            .setBody(banChatMemberResponseBody)
         mockWebServer.enqueue(mockedSuccessResponse)
     }
 


### PR DESCRIPTION
The operation has been renamed in the Telegram Bot API.