### PR TITLE
Rename getChatMembersCount to getChatMemberCount

### DIFF
--- a/telegram/api/telegram.api
+++ b/telegram/api/telegram.api
@@ -41,7 +41,7 @@ public final class com/github/kotlintelegrambot/Bot {
 	public final fun getChat (Lcom/github/kotlintelegrambot/entities/ChatId;)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
 	public final fun getChatAdministrators (Lcom/github/kotlintelegrambot/entities/ChatId;)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
 	public final fun getChatMember (Lcom/github/kotlintelegrambot/entities/ChatId;J)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
-	public final fun getChatMembersCount (Lcom/github/kotlintelegrambot/entities/ChatId;)Lkotlin/Pair;
+	public final fun getChatMemberCount (Lcom/github/kotlintelegrambot/entities/ChatId;)Lkotlin/Pair;
 	public final fun getFile (Ljava/lang/String;)Lkotlin/Pair;
 	public final fun getMe ()Lcom/github/kotlintelegrambot/types/TelegramBotResult;
 	public final fun getMyCommands ()Lcom/github/kotlintelegrambot/types/TelegramBotResult;

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -1330,7 +1330,7 @@ class Bot private constructor(
         chatId: ChatId
     ): TelegramBotResult<List<ChatMember>> = apiClient.getChatAdministrators(chatId)
 
-    fun getChatMembersCount(chatId: ChatId) = apiClient.getChatMembersCount(chatId).call()
+    fun getChatMemberCount(chatId: ChatId) = apiClient.getChatMemberCount(chatId).call()
 
     /**
      * Use this method to get information about a member of a chat.

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -899,9 +899,9 @@ internal class ApiClient(
     fun getChatAdministrators(chatId: ChatId): TelegramBotResult<List<ChatMember>> =
         service.getChatAdministrators(chatId).runApiOperation()
 
-    fun getChatMembersCount(chatId: ChatId): Call<Response<Int>> {
+    fun getChatMemberCount(chatId: ChatId): Call<Response<Int>> {
 
-        return service.getChatMembersCount(chatId)
+        return service.getChatMemberCount(chatId)
     }
 
     fun getChatMember(

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
@@ -577,8 +577,8 @@ internal interface ApiService {
         @Query(ApiConstants.CHAT_ID) chatId: ChatId
     ): Call<Response<List<ChatMember>>>
 
-    @GET("getChatMembersCount")
-    fun getChatMembersCount(
+    @GET("getChatMemberCount")
+    fun getChatMemberCount(
         @Query(ApiConstants.CHAT_ID) chatId: ChatId
     ): Call<Response<Int>>
 


### PR DESCRIPTION
The operation has been renamed in the Telegram Bot API.