### PR TITLE
Main functionality to work with ChatInviteLink and ChatJoinRequest

### DIFF
--- a/telegram/api/telegram.api
+++ b/telegram/api/telegram.api
@@ -12,14 +12,18 @@ public final class com/github/kotlintelegrambot/Bot {
 	public static synthetic fun answerPreCheckoutQuery$default (Lcom/github/kotlintelegrambot/Bot;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
 	public final fun answerShippingQuery (Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
 	public static synthetic fun answerShippingQuery$default (Lcom/github/kotlintelegrambot/Bot;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
+	public final fun approveChatJoinRequest (Lcom/github/kotlintelegrambot/entities/ChatId;J)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
 	public final fun banChatMember (Lcom/github/kotlintelegrambot/entities/ChatId;JLjava/lang/Long;)Lkotlin/Pair;
 	public static synthetic fun banChatMember$default (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/ChatId;JLjava/lang/Long;ILjava/lang/Object;)Lkotlin/Pair;
 	public final fun copyMessage (Lcom/github/kotlintelegrambot/entities/ChatId;Lcom/github/kotlintelegrambot/entities/ChatId;JLjava/lang/String;Lcom/github/kotlintelegrambot/entities/ParseMode;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Lcom/github/kotlintelegrambot/entities/ReplyMarkup;)Lkotlin/Pair;
 	public static synthetic fun copyMessage$default (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/ChatId;Lcom/github/kotlintelegrambot/entities/ChatId;JLjava/lang/String;Lcom/github/kotlintelegrambot/entities/ParseMode;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Lcom/github/kotlintelegrambot/entities/ReplyMarkup;ILjava/lang/Object;)Lkotlin/Pair;
+	public final fun createChatInviteLink (Lcom/github/kotlintelegrambot/entities/ChatId;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Boolean;)Lkotlin/Pair;
+	public static synthetic fun createChatInviteLink$default (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/ChatId;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Boolean;ILjava/lang/Object;)Lkotlin/Pair;
 	public final fun createNewStickerSet (JLjava/lang/String;Ljava/lang/String;Ljava/io/File;Ljava/lang/String;Ljava/lang/Boolean;Lcom/github/kotlintelegrambot/entities/stickers/MaskPosition;)Lkotlin/Pair;
 	public final fun createNewStickerSet (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lcom/github/kotlintelegrambot/entities/stickers/MaskPosition;)Lkotlin/Pair;
 	public static synthetic fun createNewStickerSet$default (Lcom/github/kotlintelegrambot/Bot;JLjava/lang/String;Ljava/lang/String;Ljava/io/File;Ljava/lang/String;Ljava/lang/Boolean;Lcom/github/kotlintelegrambot/entities/stickers/MaskPosition;ILjava/lang/Object;)Lkotlin/Pair;
 	public static synthetic fun createNewStickerSet$default (Lcom/github/kotlintelegrambot/Bot;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lcom/github/kotlintelegrambot/entities/stickers/MaskPosition;ILjava/lang/Object;)Lkotlin/Pair;
+	public final fun declineChatJoinRequest (Lcom/github/kotlintelegrambot/entities/ChatId;J)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
 	public final fun deleteChatPhoto (Lcom/github/kotlintelegrambot/entities/ChatId;)Lkotlin/Pair;
 	public final fun deleteChatStickerSet (Lcom/github/kotlintelegrambot/entities/ChatId;)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
 	public final fun deleteMessage (Lcom/github/kotlintelegrambot/entities/ChatId;J)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
@@ -27,6 +31,8 @@ public final class com/github/kotlintelegrambot/Bot {
 	public final fun deleteWebhook ()Lkotlin/Pair;
 	public final fun downloadFile (Ljava/lang/String;)Lkotlin/Pair;
 	public final fun downloadFileBytes (Ljava/lang/String;)[B
+	public final fun editChatInviteLink (Lcom/github/kotlintelegrambot/entities/ChatId;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Boolean;)Lkotlin/Pair;
+	public static synthetic fun editChatInviteLink$default (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/ChatId;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Boolean;ILjava/lang/Object;)Lkotlin/Pair;
 	public final fun editMessageCaption (Lcom/github/kotlintelegrambot/entities/ChatId;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/ParseMode;Lcom/github/kotlintelegrambot/entities/ReplyMarkup;)Lkotlin/Pair;
 	public static synthetic fun editMessageCaption$default (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/ChatId;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/ParseMode;Lcom/github/kotlintelegrambot/entities/ReplyMarkup;ILjava/lang/Object;)Lkotlin/Pair;
 	public final fun editMessageLiveLocation (Lcom/github/kotlintelegrambot/entities/ChatId;Ljava/lang/Long;Ljava/lang/String;FFLcom/github/kotlintelegrambot/entities/ReplyMarkup;)Lkotlin/Pair;
@@ -63,6 +69,7 @@ public final class com/github/kotlintelegrambot/Bot {
 	public static synthetic fun promoteChatMember$default (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/ChatId;JLjava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
 	public final fun restrictChatMember (Lcom/github/kotlintelegrambot/entities/ChatId;JLcom/github/kotlintelegrambot/entities/ChatPermissions;Ljava/lang/Long;)Lkotlin/Pair;
 	public static synthetic fun restrictChatMember$default (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/ChatId;JLcom/github/kotlintelegrambot/entities/ChatPermissions;Ljava/lang/Long;ILjava/lang/Object;)Lkotlin/Pair;
+	public final fun revokeChatInviteLink (Lcom/github/kotlintelegrambot/entities/ChatId;Ljava/lang/String;)Lkotlin/Pair;
 	public final fun sendAnimation (Lcom/github/kotlintelegrambot/entities/ChatId;Lcom/github/kotlintelegrambot/entities/TelegramFile;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/ParseMode;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Lcom/github/kotlintelegrambot/entities/ReplyMarkup;)Lkotlin/Pair;
 	public final fun sendAnimation (Lcom/github/kotlintelegrambot/entities/ChatId;Ljava/io/File;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Lcom/github/kotlintelegrambot/entities/ReplyMarkup;)Lkotlin/Pair;
 	public final fun sendAnimation (Lcom/github/kotlintelegrambot/entities/ChatId;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/ParseMode;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Lcom/github/kotlintelegrambot/entities/ReplyMarkup;)Lkotlin/Pair;
@@ -200,6 +207,7 @@ public final class com/github/kotlintelegrambot/dispatcher/HandlersDslKt {
 	public static synthetic fun callbackQuery$default (Lcom/github/kotlintelegrambot/dispatcher/Dispatcher;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static synthetic fun callbackQuery$default (Lcom/github/kotlintelegrambot/dispatcher/Dispatcher;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static final fun channel (Lcom/github/kotlintelegrambot/dispatcher/Dispatcher;Lkotlin/jvm/functions/Function1;)V
+	public static final fun chatJoinRequest (Lcom/github/kotlintelegrambot/dispatcher/Dispatcher;Lkotlin/jvm/functions/Function1;)V
 	public static final fun command (Lcom/github/kotlintelegrambot/dispatcher/Dispatcher;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public static final fun contact (Lcom/github/kotlintelegrambot/dispatcher/Dispatcher;Lkotlin/jvm/functions/Function1;)V
 	public static final fun dice (Lcom/github/kotlintelegrambot/dispatcher/Dispatcher;Lkotlin/jvm/functions/Function1;)V
@@ -251,6 +259,26 @@ public final class com/github/kotlintelegrambot/dispatcher/handlers/ChannelHandl
 	public final fun getUpdate ()Lcom/github/kotlintelegrambot/entities/Update;
 	public fun hashCode ()I
 	public final fun isEdition ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/kotlintelegrambot/dispatcher/handlers/ChatJoinRequestHandler : com/github/kotlintelegrambot/dispatcher/handlers/Handler {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public fun checkUpdate (Lcom/github/kotlintelegrambot/entities/Update;)Z
+	public fun handleUpdate (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;)V
+}
+
+public final class com/github/kotlintelegrambot/dispatcher/handlers/ChatJoinRequestHandlerEnvironment {
+	public final fun component1 ()Lcom/github/kotlintelegrambot/Bot;
+	public final fun component2 ()Lcom/github/kotlintelegrambot/entities/Update;
+	public final fun component3 ()Lcom/github/kotlintelegrambot/entities/ChatJoinRequest;
+	public final fun copy (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/ChatJoinRequest;)Lcom/github/kotlintelegrambot/dispatcher/handlers/ChatJoinRequestHandlerEnvironment;
+	public static synthetic fun copy$default (Lcom/github/kotlintelegrambot/dispatcher/handlers/ChatJoinRequestHandlerEnvironment;Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/ChatJoinRequest;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/dispatcher/handlers/ChatJoinRequestHandlerEnvironment;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBot ()Lcom/github/kotlintelegrambot/Bot;
+	public final fun getRequest ()Lcom/github/kotlintelegrambot/entities/ChatJoinRequest;
+	public final fun getUpdate ()Lcom/github/kotlintelegrambot/entities/Update;
+	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -579,6 +607,54 @@ public final class com/github/kotlintelegrambot/entities/ChatId$Id : com/github/
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/github/kotlintelegrambot/entities/ChatInviteLink {
+	public fun <init> (Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/User;ZZZLjava/lang/String;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/User;ZZZLjava/lang/String;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/github/kotlintelegrambot/entities/User;
+	public final fun component3 ()Z
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/Long;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/User;ZZZLjava/lang/String;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;)Lcom/github/kotlintelegrambot/entities/ChatInviteLink;
+	public static synthetic fun copy$default (Lcom/github/kotlintelegrambot/entities/ChatInviteLink;Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/User;ZZZLjava/lang/String;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/entities/ChatInviteLink;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatesJoinRequest ()Z
+	public final fun getCreator ()Lcom/github/kotlintelegrambot/entities/User;
+	public final fun getExpireDate ()Ljava/lang/Long;
+	public final fun getInviteLink ()Ljava/lang/String;
+	public final fun getMemberLimit ()Ljava/lang/Integer;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPendingJoinRequestCount ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public final fun isPrimary ()Z
+	public final fun isRevoked ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/kotlintelegrambot/entities/ChatJoinRequest {
+	public fun <init> (Lcom/github/kotlintelegrambot/entities/Chat;Lcom/github/kotlintelegrambot/entities/User;JLjava/lang/String;Lcom/github/kotlintelegrambot/entities/ChatInviteLink;)V
+	public synthetic fun <init> (Lcom/github/kotlintelegrambot/entities/Chat;Lcom/github/kotlintelegrambot/entities/User;JLjava/lang/String;Lcom/github/kotlintelegrambot/entities/ChatInviteLink;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/github/kotlintelegrambot/entities/Chat;
+	public final fun component2 ()Lcom/github/kotlintelegrambot/entities/User;
+	public final fun component3 ()J
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Lcom/github/kotlintelegrambot/entities/ChatInviteLink;
+	public final fun copy (Lcom/github/kotlintelegrambot/entities/Chat;Lcom/github/kotlintelegrambot/entities/User;JLjava/lang/String;Lcom/github/kotlintelegrambot/entities/ChatInviteLink;)Lcom/github/kotlintelegrambot/entities/ChatJoinRequest;
+	public static synthetic fun copy$default (Lcom/github/kotlintelegrambot/entities/ChatJoinRequest;Lcom/github/kotlintelegrambot/entities/Chat;Lcom/github/kotlintelegrambot/entities/User;JLjava/lang/String;Lcom/github/kotlintelegrambot/entities/ChatInviteLink;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/entities/ChatJoinRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBio ()Ljava/lang/String;
+	public final fun getChat ()Lcom/github/kotlintelegrambot/entities/Chat;
+	public final fun getDate ()J
+	public final fun getFrom ()Lcom/github/kotlintelegrambot/entities/User;
+	public final fun getInviteLink ()Lcom/github/kotlintelegrambot/entities/ChatInviteLink;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/github/kotlintelegrambot/entities/ChatLocation {
 	public fun <init> (Lcom/github/kotlintelegrambot/entities/Location;Ljava/lang/String;)V
 	public final fun component1 ()Lcom/github/kotlintelegrambot/entities/Location;
@@ -593,8 +669,8 @@ public final class com/github/kotlintelegrambot/entities/ChatLocation {
 }
 
 public final class com/github/kotlintelegrambot/entities/ChatMember {
-	public fun <init> (Lcom/github/kotlintelegrambot/entities/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (Lcom/github/kotlintelegrambot/entities/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/github/kotlintelegrambot/entities/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Lcom/github/kotlintelegrambot/entities/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/github/kotlintelegrambot/entities/User;
 	public final fun component10 ()Ljava/lang/Boolean;
 	public final fun component11 ()Ljava/lang/Boolean;
@@ -608,6 +684,7 @@ public final class com/github/kotlintelegrambot/entities/ChatMember {
 	public final fun component19 ()Ljava/lang/Boolean;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component20 ()Ljava/lang/Boolean;
+	public final fun component21 ()Ljava/lang/Boolean;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/Boolean;
 	public final fun component5 ()Ljava/lang/Integer;
@@ -615,8 +692,8 @@ public final class com/github/kotlintelegrambot/entities/ChatMember {
 	public final fun component7 ()Ljava/lang/Boolean;
 	public final fun component8 ()Ljava/lang/Boolean;
 	public final fun component9 ()Ljava/lang/Boolean;
-	public final fun copy (Lcom/github/kotlintelegrambot/entities/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lcom/github/kotlintelegrambot/entities/ChatMember;
-	public static synthetic fun copy$default (Lcom/github/kotlintelegrambot/entities/ChatMember;Lcom/github/kotlintelegrambot/entities/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/entities/ChatMember;
+	public final fun copy (Lcom/github/kotlintelegrambot/entities/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lcom/github/kotlintelegrambot/entities/ChatMember;
+	public static synthetic fun copy$default (Lcom/github/kotlintelegrambot/entities/ChatMember;Lcom/github/kotlintelegrambot/entities/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/entities/ChatMember;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCanAddWebPagePreviews ()Ljava/lang/Boolean;
 	public final fun getCanBeEdited ()Ljava/lang/Boolean;
@@ -624,6 +701,7 @@ public final class com/github/kotlintelegrambot/entities/ChatMember {
 	public final fun getCanDeleteMessages ()Ljava/lang/Boolean;
 	public final fun getCanEditMessages ()Ljava/lang/Boolean;
 	public final fun getCanInviteUsers ()Ljava/lang/Boolean;
+	public final fun getCanManageChat ()Ljava/lang/Boolean;
 	public final fun getCanPinMessages ()Ljava/lang/Boolean;
 	public final fun getCanPostMessages ()Ljava/lang/Boolean;
 	public final fun getCanPromoteMembers ()Ljava/lang/Boolean;
@@ -639,6 +717,28 @@ public final class com/github/kotlintelegrambot/entities/ChatMember {
 	public fun hashCode ()I
 	public final fun isAnonymous ()Ljava/lang/Boolean;
 	public final fun isMember ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/kotlintelegrambot/entities/ChatMemberUpdated {
+	public fun <init> (Lcom/github/kotlintelegrambot/entities/Chat;Lcom/github/kotlintelegrambot/entities/User;JLcom/github/kotlintelegrambot/entities/ChatMember;Lcom/github/kotlintelegrambot/entities/ChatMember;Lcom/github/kotlintelegrambot/entities/ChatInviteLink;)V
+	public synthetic fun <init> (Lcom/github/kotlintelegrambot/entities/Chat;Lcom/github/kotlintelegrambot/entities/User;JLcom/github/kotlintelegrambot/entities/ChatMember;Lcom/github/kotlintelegrambot/entities/ChatMember;Lcom/github/kotlintelegrambot/entities/ChatInviteLink;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/github/kotlintelegrambot/entities/Chat;
+	public final fun component2 ()Lcom/github/kotlintelegrambot/entities/User;
+	public final fun component3 ()J
+	public final fun component4 ()Lcom/github/kotlintelegrambot/entities/ChatMember;
+	public final fun component5 ()Lcom/github/kotlintelegrambot/entities/ChatMember;
+	public final fun component6 ()Lcom/github/kotlintelegrambot/entities/ChatInviteLink;
+	public final fun copy (Lcom/github/kotlintelegrambot/entities/Chat;Lcom/github/kotlintelegrambot/entities/User;JLcom/github/kotlintelegrambot/entities/ChatMember;Lcom/github/kotlintelegrambot/entities/ChatMember;Lcom/github/kotlintelegrambot/entities/ChatInviteLink;)Lcom/github/kotlintelegrambot/entities/ChatMemberUpdated;
+	public static synthetic fun copy$default (Lcom/github/kotlintelegrambot/entities/ChatMemberUpdated;Lcom/github/kotlintelegrambot/entities/Chat;Lcom/github/kotlintelegrambot/entities/User;JLcom/github/kotlintelegrambot/entities/ChatMember;Lcom/github/kotlintelegrambot/entities/ChatMember;Lcom/github/kotlintelegrambot/entities/ChatInviteLink;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/entities/ChatMemberUpdated;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChat ()Lcom/github/kotlintelegrambot/entities/Chat;
+	public final fun getDate ()J
+	public final fun getFrom ()Lcom/github/kotlintelegrambot/entities/User;
+	public final fun getInviteLink ()Lcom/github/kotlintelegrambot/entities/ChatInviteLink;
+	public final fun getNewChatMember ()Lcom/github/kotlintelegrambot/entities/ChatMember;
+	public final fun getOldChatMember ()Lcom/github/kotlintelegrambot/entities/ChatMember;
+	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -1180,12 +1280,15 @@ public final class com/github/kotlintelegrambot/entities/TelegramFile$ByUrl : co
 }
 
 public final class com/github/kotlintelegrambot/entities/Update : com/github/kotlintelegrambot/types/ConsumableObject, com/github/kotlintelegrambot/types/DispatchableObject {
-	public fun <init> (JLcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/InlineQuery;Lcom/github/kotlintelegrambot/entities/ChosenInlineResult;Lcom/github/kotlintelegrambot/entities/CallbackQuery;Lcom/github/kotlintelegrambot/entities/payments/ShippingQuery;Lcom/github/kotlintelegrambot/entities/payments/PreCheckoutQuery;Lcom/github/kotlintelegrambot/entities/polls/Poll;Lcom/github/kotlintelegrambot/entities/polls/PollAnswer;)V
-	public synthetic fun <init> (JLcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/InlineQuery;Lcom/github/kotlintelegrambot/entities/ChosenInlineResult;Lcom/github/kotlintelegrambot/entities/CallbackQuery;Lcom/github/kotlintelegrambot/entities/payments/ShippingQuery;Lcom/github/kotlintelegrambot/entities/payments/PreCheckoutQuery;Lcom/github/kotlintelegrambot/entities/polls/Poll;Lcom/github/kotlintelegrambot/entities/polls/PollAnswer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (JLcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/InlineQuery;Lcom/github/kotlintelegrambot/entities/ChosenInlineResult;Lcom/github/kotlintelegrambot/entities/CallbackQuery;Lcom/github/kotlintelegrambot/entities/payments/ShippingQuery;Lcom/github/kotlintelegrambot/entities/payments/PreCheckoutQuery;Lcom/github/kotlintelegrambot/entities/polls/Poll;Lcom/github/kotlintelegrambot/entities/polls/PollAnswer;Lcom/github/kotlintelegrambot/entities/ChatMemberUpdated;Lcom/github/kotlintelegrambot/entities/ChatMemberUpdated;Lcom/github/kotlintelegrambot/entities/ChatJoinRequest;)V
+	public synthetic fun <init> (JLcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/InlineQuery;Lcom/github/kotlintelegrambot/entities/ChosenInlineResult;Lcom/github/kotlintelegrambot/entities/CallbackQuery;Lcom/github/kotlintelegrambot/entities/payments/ShippingQuery;Lcom/github/kotlintelegrambot/entities/payments/PreCheckoutQuery;Lcom/github/kotlintelegrambot/entities/polls/Poll;Lcom/github/kotlintelegrambot/entities/polls/PollAnswer;Lcom/github/kotlintelegrambot/entities/ChatMemberUpdated;Lcom/github/kotlintelegrambot/entities/ChatMemberUpdated;Lcom/github/kotlintelegrambot/entities/ChatJoinRequest;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()J
 	public final fun component10 ()Lcom/github/kotlintelegrambot/entities/payments/PreCheckoutQuery;
 	public final fun component11 ()Lcom/github/kotlintelegrambot/entities/polls/Poll;
 	public final fun component12 ()Lcom/github/kotlintelegrambot/entities/polls/PollAnswer;
+	public final fun component13 ()Lcom/github/kotlintelegrambot/entities/ChatMemberUpdated;
+	public final fun component14 ()Lcom/github/kotlintelegrambot/entities/ChatMemberUpdated;
+	public final fun component15 ()Lcom/github/kotlintelegrambot/entities/ChatJoinRequest;
 	public final fun component2 ()Lcom/github/kotlintelegrambot/entities/Message;
 	public final fun component3 ()Lcom/github/kotlintelegrambot/entities/Message;
 	public final fun component4 ()Lcom/github/kotlintelegrambot/entities/Message;
@@ -1194,16 +1297,19 @@ public final class com/github/kotlintelegrambot/entities/Update : com/github/kot
 	public final fun component7 ()Lcom/github/kotlintelegrambot/entities/ChosenInlineResult;
 	public final fun component8 ()Lcom/github/kotlintelegrambot/entities/CallbackQuery;
 	public final fun component9 ()Lcom/github/kotlintelegrambot/entities/payments/ShippingQuery;
-	public final fun copy (JLcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/InlineQuery;Lcom/github/kotlintelegrambot/entities/ChosenInlineResult;Lcom/github/kotlintelegrambot/entities/CallbackQuery;Lcom/github/kotlintelegrambot/entities/payments/ShippingQuery;Lcom/github/kotlintelegrambot/entities/payments/PreCheckoutQuery;Lcom/github/kotlintelegrambot/entities/polls/Poll;Lcom/github/kotlintelegrambot/entities/polls/PollAnswer;)Lcom/github/kotlintelegrambot/entities/Update;
-	public static synthetic fun copy$default (Lcom/github/kotlintelegrambot/entities/Update;JLcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/InlineQuery;Lcom/github/kotlintelegrambot/entities/ChosenInlineResult;Lcom/github/kotlintelegrambot/entities/CallbackQuery;Lcom/github/kotlintelegrambot/entities/payments/ShippingQuery;Lcom/github/kotlintelegrambot/entities/payments/PreCheckoutQuery;Lcom/github/kotlintelegrambot/entities/polls/Poll;Lcom/github/kotlintelegrambot/entities/polls/PollAnswer;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/entities/Update;
+	public final fun copy (JLcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/InlineQuery;Lcom/github/kotlintelegrambot/entities/ChosenInlineResult;Lcom/github/kotlintelegrambot/entities/CallbackQuery;Lcom/github/kotlintelegrambot/entities/payments/ShippingQuery;Lcom/github/kotlintelegrambot/entities/payments/PreCheckoutQuery;Lcom/github/kotlintelegrambot/entities/polls/Poll;Lcom/github/kotlintelegrambot/entities/polls/PollAnswer;Lcom/github/kotlintelegrambot/entities/ChatMemberUpdated;Lcom/github/kotlintelegrambot/entities/ChatMemberUpdated;Lcom/github/kotlintelegrambot/entities/ChatJoinRequest;)Lcom/github/kotlintelegrambot/entities/Update;
+	public static synthetic fun copy$default (Lcom/github/kotlintelegrambot/entities/Update;JLcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/Message;Lcom/github/kotlintelegrambot/entities/InlineQuery;Lcom/github/kotlintelegrambot/entities/ChosenInlineResult;Lcom/github/kotlintelegrambot/entities/CallbackQuery;Lcom/github/kotlintelegrambot/entities/payments/ShippingQuery;Lcom/github/kotlintelegrambot/entities/payments/PreCheckoutQuery;Lcom/github/kotlintelegrambot/entities/polls/Poll;Lcom/github/kotlintelegrambot/entities/polls/PollAnswer;Lcom/github/kotlintelegrambot/entities/ChatMemberUpdated;Lcom/github/kotlintelegrambot/entities/ChatMemberUpdated;Lcom/github/kotlintelegrambot/entities/ChatJoinRequest;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/entities/Update;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCallbackQuery ()Lcom/github/kotlintelegrambot/entities/CallbackQuery;
 	public final fun getChannelPost ()Lcom/github/kotlintelegrambot/entities/Message;
+	public final fun getChatJoinRequest ()Lcom/github/kotlintelegrambot/entities/ChatJoinRequest;
+	public final fun getChatMember ()Lcom/github/kotlintelegrambot/entities/ChatMemberUpdated;
 	public final fun getChosenInlineResult ()Lcom/github/kotlintelegrambot/entities/ChosenInlineResult;
 	public final fun getEditedChannelPost ()Lcom/github/kotlintelegrambot/entities/Message;
 	public final fun getEditedMessage ()Lcom/github/kotlintelegrambot/entities/Message;
 	public final fun getInlineQuery ()Lcom/github/kotlintelegrambot/entities/InlineQuery;
 	public final fun getMessage ()Lcom/github/kotlintelegrambot/entities/Message;
+	public final fun getMyChatMember ()Lcom/github/kotlintelegrambot/entities/ChatMemberUpdated;
 	public final fun getPoll ()Lcom/github/kotlintelegrambot/entities/polls/Poll;
 	public final fun getPollAnswer ()Lcom/github/kotlintelegrambot/entities/polls/PollAnswer;
 	public final fun getPreCheckoutQuery ()Lcom/github/kotlintelegrambot/entities/payments/PreCheckoutQuery;

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -1264,10 +1264,72 @@ class Bot private constructor(
         canPromoteMembers
     )
 
+    fun approveChatJoinRequest(
+        chatId: ChatId,
+        userId: Long,
+    ): TelegramBotResult<Boolean> = apiClient.approveChatJoinRequest(
+        chatId,
+        userId,
+    )
+
+    fun declineChatJoinRequest(
+        chatId: ChatId,
+        userId: Long,
+    ): TelegramBotResult<Boolean> = apiClient.declineChatJoinRequest(
+        chatId,
+        userId,
+    )
+
     fun setChatPermissions(chatId: ChatId, permissions: ChatPermissions) =
         apiClient.setChatPermissions(chatId, permissions).call()
 
     fun exportChatInviteLink(chatId: ChatId) = apiClient.exportChatInviteLink(chatId).call()
+
+    /**
+     * Use this method to create new invite link. On success, ChatInviteLink is returned.
+     *
+     * @param chatId Unique identifier for the target chat or username of the target channel
+     * (in the format @channelusername).
+     * @param name Invite link name; 0-32 characters.
+     * @param expireDate Point in time (Unix timestamp) when the link will expire.
+     * @param memberLimit Maximum number of users that can be members of the chat simultaneously
+     * after joining the chat via this invite link; 1-99999.
+     * @param createsJoinRequest Pass True, if users joining the chat via the link need to be approved
+     * by chat administrators. If True, member_limit can't be specified
+     *
+     * @return created ChatInviteLink.
+     */
+    fun createChatInviteLink(
+        chatId: ChatId,
+        name: String? = null,
+        expireDate: Long? = null,
+        memberLimit: Int? = null,
+        createsJoinRequest: Boolean? = null,
+    ) = apiClient.createChatInviteLink(
+        chatId,
+        name,
+        expireDate,
+        memberLimit,
+        createsJoinRequest
+    ).call()
+
+    fun editChatInviteLink(
+        chatId: ChatId,
+        inviteLink: String,
+        name: String? = null,
+        expireDate: Long? = null,
+        memberLimit: Int? = null,
+        createsJoinRequest: Boolean? = null,
+    ) = apiClient.editChatInviteLink(
+        chatId,
+        inviteLink,
+        name,
+        expireDate,
+        memberLimit,
+        createsJoinRequest,
+    ).call()
+
+    fun revokeChatInviteLink(chatId: ChatId, inviteLink: String) = apiClient.revokeChatInviteLink(chatId, inviteLink).call()
 
     fun setChatPhoto(
         chatId: ChatId,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/HandlersDsl.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/HandlersDsl.kt
@@ -2,6 +2,7 @@ package com.github.kotlintelegrambot.dispatcher
 
 import com.github.kotlintelegrambot.dispatcher.handlers.CallbackQueryHandler
 import com.github.kotlintelegrambot.dispatcher.handlers.ChannelHandler
+import com.github.kotlintelegrambot.dispatcher.handlers.ChatJoinRequestHandler
 import com.github.kotlintelegrambot.dispatcher.handlers.CommandHandler
 import com.github.kotlintelegrambot.dispatcher.handlers.ContactHandler
 import com.github.kotlintelegrambot.dispatcher.handlers.DiceHandler
@@ -10,6 +11,7 @@ import com.github.kotlintelegrambot.dispatcher.handlers.HandleAnimation
 import com.github.kotlintelegrambot.dispatcher.handlers.HandleAudio
 import com.github.kotlintelegrambot.dispatcher.handlers.HandleCallbackQuery
 import com.github.kotlintelegrambot.dispatcher.handlers.HandleChannelPost
+import com.github.kotlintelegrambot.dispatcher.handlers.HandleChatJoinRequest
 import com.github.kotlintelegrambot.dispatcher.handlers.HandleCommand
 import com.github.kotlintelegrambot.dispatcher.handlers.HandleContact
 import com.github.kotlintelegrambot.dispatcher.handlers.HandleDice
@@ -157,4 +159,8 @@ fun Dispatcher.pollAnswer(body: HandlePollAnswer) {
 
 fun Dispatcher.dice(body: HandleDice) {
     addHandler(DiceHandler(body))
+}
+
+fun Dispatcher.chatJoinRequest(body: HandleChatJoinRequest) {
+    addHandler(ChatJoinRequestHandler(body))
 }

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/Callbacks.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/Callbacks.kt
@@ -33,6 +33,8 @@ typealias HandleInlineQuery = InlineQueryHandlerEnvironment.() -> Unit
 
 typealias HandleNewChatMembers = NewChatMembersHandlerEnvironment.() -> Unit
 
+typealias HandleChatJoinRequest = ChatJoinRequestHandlerEnvironment.() -> Unit
+
 typealias HandlePollAnswer = PollAnswerHandlerEnvironment.() -> Unit
 
 typealias HandleDice = DiceHandlerEnvironment.() -> Unit

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/ChatJoinRequestHandler.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/ChatJoinRequestHandler.kt
@@ -1,0 +1,31 @@
+package com.github.kotlintelegrambot.dispatcher.handlers
+
+import com.github.kotlintelegrambot.Bot
+import com.github.kotlintelegrambot.entities.ChatJoinRequest
+import com.github.kotlintelegrambot.entities.Update
+
+data class ChatJoinRequestHandlerEnvironment internal constructor(
+    val bot: Bot,
+    val update: Update,
+    val request: ChatJoinRequest
+)
+
+class ChatJoinRequestHandler(
+    private val handleChatJoinRequest: HandleChatJoinRequest
+) : Handler {
+    override fun checkUpdate(update: Update): Boolean {
+        return update.chatJoinRequest != null
+    }
+
+    override fun handleUpdate(bot: Bot, update: Update) {
+        val request = update.chatJoinRequest
+        checkNotNull(request)
+
+        val newChatMembersHandlerEnv = ChatJoinRequestHandlerEnvironment(
+            bot,
+            update,
+            request
+        )
+        handleChatJoinRequest.invoke(newChatMembersHandlerEnv)
+    }
+}

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/ChatInviteLink.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/ChatInviteLink.kt
@@ -1,0 +1,18 @@
+package com.github.kotlintelegrambot.entities
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Represents a Telegram ChatInviteLink added in Bot API 5.1.
+ */
+data class ChatInviteLink(
+    @SerializedName("invite_link") val inviteLink: String,
+    @SerializedName("creator") val creator: User,
+    @SerializedName("creates_join_request") val createsJoinRequest: Boolean,
+    @SerializedName("is_primary") val isPrimary: Boolean,
+    @SerializedName("is_revoked") val isRevoked: Boolean,
+    @SerializedName("name") val name: String? = null,
+    @SerializedName("expire_date") val expireDate: Long? = null,
+    @SerializedName("member_limit") val memberLimit: Int? = null,
+    @SerializedName("pending_join_request_count") val pendingJoinRequestCount: Int? = null,
+)

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/ChatJoinRequest.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/ChatJoinRequest.kt
@@ -1,0 +1,11 @@
+package com.github.kotlintelegrambot.entities
+
+import com.google.gson.annotations.SerializedName
+
+data class ChatJoinRequest(
+    @SerializedName("chat") val chat: Chat,
+    @SerializedName("from") val from: User,
+    @SerializedName("date") val date: Long,
+    @SerializedName("bio") val bio: String? = null,
+    @SerializedName("invite_link") val inviteLink: ChatInviteLink? = null,
+)

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/ChatMember.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/ChatMember.kt
@@ -22,5 +22,6 @@ data class ChatMember(
     @SerializedName("can_send_media_messages") val canSendMediaMessages: Boolean? = null,
     @SerializedName("can_send_polls") val canSendPolls: Boolean? = null,
     @SerializedName("can_send_other_messages") val canSendOtherMessages: Boolean? = null,
-    @SerializedName("can_add_web_page_previews") val canAddWebPagePreviews: Boolean? = null
+    @SerializedName("can_add_web_page_previews") val canAddWebPagePreviews: Boolean? = null,
+    @SerializedName("can_manage_chat") val canManageChat: Boolean? = null,
 )

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/ChatMemberUpdated.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/ChatMemberUpdated.kt
@@ -1,0 +1,12 @@
+package com.github.kotlintelegrambot.entities
+
+import com.google.gson.annotations.SerializedName
+
+data class ChatMemberUpdated(
+    @SerializedName("chat") val chat: Chat,
+    @SerializedName("from") val from: User,
+    @SerializedName("date") val date: Long,
+    @SerializedName("old_chat_member") val oldChatMember: ChatMember,
+    @SerializedName("new_chat_member") val newChatMember: ChatMember,
+    @SerializedName("invite_link") val inviteLink: ChatInviteLink? = null,
+)

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/Update.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/Update.kt
@@ -20,7 +20,10 @@ data class Update constructor(
     @Name("shipping_query") val shippingQuery: ShippingQuery? = null,
     @Name("pre_checkout_query") val preCheckoutQuery: PreCheckoutQuery? = null,
     @Name("poll") val poll: Poll? = null,
-    @Name("poll_answer") val pollAnswer: PollAnswer? = null
+    @Name("poll_answer") val pollAnswer: PollAnswer? = null,
+    @Name("my_chat_member") val myChatMember: ChatMemberUpdated? = null,
+    @Name("chat_member") val chatMember: ChatMemberUpdated? = null,
+    @Name("chat_join_request") val chatJoinRequest: ChatJoinRequest? = null,
 ) : DispatchableObject, ConsumableObject()
 
 /**

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -4,6 +4,7 @@ import com.github.kotlintelegrambot.entities.BotCommand
 import com.github.kotlintelegrambot.entities.Chat
 import com.github.kotlintelegrambot.entities.ChatAction
 import com.github.kotlintelegrambot.entities.ChatId
+import com.github.kotlintelegrambot.entities.ChatInviteLink
 import com.github.kotlintelegrambot.entities.ChatMember
 import com.github.kotlintelegrambot.entities.ChatPermissions
 import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
@@ -838,6 +839,22 @@ internal class ApiClient(
         canPromoteMembers
     ).runApiOperation()
 
+    fun approveChatJoinRequest(
+        chatId: ChatId,
+        messageId: Long,
+    ): TelegramBotResult<Boolean> = service.approveChatJoinRequest(
+        chatId,
+        messageId,
+    ).runApiOperation()
+
+    fun declineChatJoinRequest(
+        chatId: ChatId,
+        messageId: Long,
+    ): TelegramBotResult<Boolean> = service.declineChatJoinRequest(
+        chatId,
+        messageId,
+    ).runApiOperation()
+
     fun setChatPermissions(chatId: ChatId, permissions: ChatPermissions): Call<Response<Boolean>> {
 
         return service.setChatPermissions(chatId, gson.toJson(permissions))
@@ -846,6 +863,47 @@ internal class ApiClient(
     fun exportChatInviteLink(chatId: ChatId): Call<Response<String>> {
 
         return service.exportChatInviteLink(chatId)
+    }
+
+    fun createChatInviteLink(
+        chatId: ChatId,
+        name: String?,
+        expireDate: Long?,
+        memberLimit: Int?,
+        createsJoinRequest: Boolean?,
+    ): Call<Response<ChatInviteLink>> {
+
+        return service.createChatInviteLink(
+            chatId,
+            name,
+            expireDate,
+            memberLimit,
+            createsJoinRequest
+        )
+    }
+
+    fun editChatInviteLink(
+        chatId: ChatId,
+        inviteLink: String,
+        name: String?,
+        expireDate: Long?,
+        memberLimit: Int?,
+        createsJoinRequest: Boolean?,
+    ): Call<Response<ChatInviteLink>> {
+
+        return service.editChatInviteLink(
+            chatId,
+            inviteLink,
+            name,
+            expireDate,
+            memberLimit,
+            createsJoinRequest,
+        )
+    }
+
+    fun revokeChatInviteLink(chatId: ChatId, inviteLink: String): Call<Response<ChatInviteLink>> {
+
+        return service.revokeChatInviteLink(chatId, inviteLink)
     }
 
     fun setChatPhoto(

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
@@ -4,6 +4,7 @@ import com.github.kotlintelegrambot.entities.BotCommand
 import com.github.kotlintelegrambot.entities.Chat
 import com.github.kotlintelegrambot.entities.ChatAction
 import com.github.kotlintelegrambot.entities.ChatId
+import com.github.kotlintelegrambot.entities.ChatInviteLink
 import com.github.kotlintelegrambot.entities.ChatMember
 import com.github.kotlintelegrambot.entities.Message
 import com.github.kotlintelegrambot.entities.MessageId
@@ -503,6 +504,20 @@ internal interface ApiService {
     ): Call<Response<Boolean>>
 
     @FormUrlEncoded
+    @POST("approveChatJoinRequest")
+    fun approveChatJoinRequest(
+        @Field(ApiConstants.CHAT_ID) chatId: ChatId,
+        @Field(ApiConstants.USER_ID) userId: Long,
+    ): Call<Response<Boolean>>
+
+    @FormUrlEncoded
+    @POST("declineChatJoinRequest")
+    fun declineChatJoinRequest(
+        @Field(ApiConstants.CHAT_ID) chatId: ChatId,
+        @Field(ApiConstants.USER_ID) userId: Long,
+    ): Call<Response<Boolean>>
+
+    @FormUrlEncoded
     @POST("setChatPermissions")
     fun setChatPermissions(
         @Field(ApiConstants.CHAT_ID) chatId: ChatId,
@@ -514,6 +529,34 @@ internal interface ApiService {
     fun exportChatInviteLink(
         @Field(ApiConstants.CHAT_ID) chatId: ChatId
     ): Call<Response<String>>
+
+    @FormUrlEncoded
+    @POST("createChatInviteLink")
+    fun createChatInviteLink(
+        @Field(ApiConstants.CHAT_ID) chatId: ChatId,
+        @Field("name") name: String?,
+        @Field("expire_date") expireDate: Long?,
+        @Field("member_limit") memberLimit: Int?,
+        @Field("creates_join_request") createsJoinRequest: Boolean?,
+    ): Call<Response<ChatInviteLink>>
+
+    @FormUrlEncoded
+    @POST("editChatInviteLink")
+    fun editChatInviteLink(
+        @Field(ApiConstants.CHAT_ID) chatId: ChatId,
+        @Field("invite_link") inviteLink: String,
+        @Field("name") name: String?,
+        @Field("expire_date") expireDate: Long?,
+        @Field("member_limit") memberLimit: Int?,
+        @Field("creates_join_request") createsJoinRequest: Boolean?,
+    ): Call<Response<ChatInviteLink>>
+
+    @FormUrlEncoded
+    @POST("revokeChatInviteLink")
+    fun revokeChatInviteLink(
+        @Field(ApiConstants.CHAT_ID) chatId: ChatId,
+        @Field("invite_link") inviteLink: String,
+    ): Call<Response<ChatInviteLink>>
 
     @Multipart
     @POST("setChatPhoto")

--- a/telegram/src/test/kotlin/Mothers.kt
+++ b/telegram/src/test/kotlin/Mothers.kt
@@ -1,5 +1,8 @@
 import com.github.kotlintelegrambot.entities.CallbackQuery
 import com.github.kotlintelegrambot.entities.Chat
+import com.github.kotlintelegrambot.entities.ChatInviteLink
+import com.github.kotlintelegrambot.entities.ChatJoinRequest
+import com.github.kotlintelegrambot.entities.ChatMemberUpdated
 import com.github.kotlintelegrambot.entities.Contact
 import com.github.kotlintelegrambot.entities.Game
 import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
@@ -41,7 +44,10 @@ fun anyUpdate(
     preCheckoutQuery: PreCheckoutQuery? = null,
     shippingQuery: ShippingQuery? = null,
     inlineQuery: InlineQuery? = null,
-    pollAnswer: PollAnswer? = null
+    pollAnswer: PollAnswer? = null,
+    myChatMember: ChatMemberUpdated? = null,
+    chatMember: ChatMemberUpdated? = null,
+    chatJoinRequest: ChatJoinRequest? = null,
 ): Update = Update(
     updateId = updateId,
     message = message,
@@ -52,7 +58,10 @@ fun anyUpdate(
     preCheckoutQuery = preCheckoutQuery,
     shippingQuery = shippingQuery,
     inlineQuery = inlineQuery,
-    pollAnswer = pollAnswer
+    pollAnswer = pollAnswer,
+    myChatMember = myChatMember,
+    chatMember = chatMember,
+    chatJoinRequest = chatJoinRequest,
 )
 
 private const val ANY_MESSAGE_ID = 32142353L
@@ -472,4 +481,42 @@ fun anyPreCheckoutQuery(
     invoicePayload = invoicePayload,
     shippingOptionId = shippingOptionId,
     orderInfo = orderInfo
+)
+
+private const val ANY_INVITE_LINK = "https://t.me/0000i"
+
+fun anyChatInviteLink(
+    inviteLink: String = ANY_INVITE_LINK,
+    creator: User = anyUser(),
+    createsJoinRequest: Boolean = true,
+    isPrimary: Boolean = false,
+    isRevoked: Boolean = false,
+    name: String? = null,
+    expireDate: Long? = null,
+    memberLimit: Int? = null,
+    pendingJoinRequestCount: Int? = null,
+): ChatInviteLink = ChatInviteLink(
+    inviteLink = inviteLink,
+    creator = creator,
+    createsJoinRequest = createsJoinRequest,
+    isPrimary = isPrimary,
+    isRevoked = isRevoked,
+    name = name,
+    expireDate = expireDate,
+    memberLimit = memberLimit,
+    pendingJoinRequestCount = pendingJoinRequestCount,
+)
+
+fun anyChatJoinRequest(
+    chat: Chat = anyChat(),
+    from: User = anyUser(),
+    date: Long = ANY_DATE,
+    bio: String? = null,
+    inviteLink: ChatInviteLink? = anyChatInviteLink(),
+): ChatJoinRequest = ChatJoinRequest(
+    chat = chat,
+    from = from,
+    date = date,
+    bio = bio,
+    inviteLink = inviteLink,
 )

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/ChatJoinRequestHandlerTest.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/ChatJoinRequestHandlerTest.kt
@@ -1,0 +1,58 @@
+package com.github.kotlintelegrambot.dispatcher.handlers
+
+import anyChatJoinRequest
+import anyMessage
+import anyUpdate
+import com.github.kotlintelegrambot.Bot
+import io.mockk.mockk
+import io.mockk.verify
+import junit.framework.TestCase
+import org.junit.jupiter.api.Test
+
+class ChatJoinRequestHandlerTest {
+    private val handlerFunctionMock = mockk<ChatJoinRequestHandlerEnvironment.() -> Unit>(relaxed = true)
+
+    private val sut = ChatJoinRequestHandler(handlerFunctionMock)
+
+    @Test
+    fun `checkUpdate returns false for the update with non null message`() {
+        val anyCommand = anyUpdate(message = anyMessage())
+
+        val checkUpdateResult = sut.checkUpdate(anyCommand)
+
+        TestCase.assertFalse(checkUpdateResult)
+    }
+
+    @Test
+    fun `checkUpdate returns true for the update with chatJoinRequest and null message`() {
+        val anyCommandWithArguments = anyUpdate(
+            message = null,
+            chatJoinRequest = anyChatJoinRequest()
+        )
+
+        val checkUpdateResult = sut.checkUpdate(anyCommandWithArguments)
+
+        TestCase.assertTrue(checkUpdateResult)
+    }
+
+    @Test
+    fun `checkUpdate returns false for the update with empty message and chatJoinRequest`() {
+        val anyOtherCommand = anyUpdate(message = null, chatJoinRequest = null)
+
+        val checkUpdateResult = sut.checkUpdate(anyOtherCommand)
+
+        TestCase.assertFalse(checkUpdateResult)
+    }
+
+    @Test
+    fun `chatJoinRequest update is properly dispatched to the handler function`() {
+        val botMock = mockk<Bot>()
+        val request = anyChatJoinRequest()
+        val anyUpdate = anyUpdate(message = null, chatJoinRequest = anyChatJoinRequest())
+
+        sut.handleUpdate(botMock, anyUpdate)
+
+        val expectedArgs = ChatJoinRequestHandlerEnvironment(botMock, anyUpdate, request)
+        verify { handlerFunctionMock.invoke(expectedArgs) }
+    }
+}

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/GetChatAdministratorsIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/GetChatAdministratorsIT.kt
@@ -47,6 +47,7 @@ class GetChatAdministratorsIT : ApiClientIT() {
                 canPinMessages = true,
                 canPromoteMembers = true,
                 isAnonymous = false,
+                canManageChat = true,
             ),
             ChatMember(
                 user = User(
@@ -84,7 +85,8 @@ class GetChatAdministratorsIT : ApiClientIT() {
                         "can_restrict_members": true,
                         "can_pin_messages": true,
                         "can_promote_members": true,
-                        "is_anonymous": false
+                        "is_anonymous": false,
+                        "can_manage_chat": true
                     },
                     {
                         "user": {


### PR DESCRIPTION
Hey, thanks for your project, it helped me a lot. 
I've added main functionality to work with ChatInviteLink and ChatJoinRequest from API 5.1/5.4.
And new handler to process ChatJoinRequests in bot.

I've got some questions:
1) I'm little confused between usages of .call() and .runApiOperation() so I might have used them wrong in my calls. 
2) Tests are passing, except 
- SetWebhookIT > setWebhook with certificate as file$telegram()
- SetWebhookIT > setWebhook with certificate as file and with ip address$telegram()
because of header length. And I'm not sure how to compute that length correctly (except to copy from actual part).

