### PR TITLE
Fix kotlin telegram bot issue #238:

### DIFF
--- a/telegram/api/telegram.api
+++ b/telegram/api/telegram.api
@@ -3120,6 +3120,7 @@ public final class com/github/kotlintelegrambot/network/LabeledPriceList {
 
 public final class com/github/kotlintelegrambot/network/MediaTypeConstants {
 	public static final field AUDIO_OGG Ljava/lang/String;
+	public static final field DOCUMENT Ljava/lang/String;
 	public static final field IMAGE Ljava/lang/String;
 	public static final field INSTANCE Lcom/github/kotlintelegrambot/network/MediaTypeConstants;
 	public static final field UTF_8_TEXT Ljava/lang/String;

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/MediaTypeConstants.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/MediaTypeConstants.kt
@@ -2,6 +2,7 @@ package com.github.kotlintelegrambot.network
 
 object MediaTypeConstants {
     const val UTF_8_TEXT = "text/*; charset=utf-8"
+    const val DOCUMENT = "document/*"
     const val AUDIO_OGG = "audio/ogg"
     const val IMAGE = "image/*"
     const val VIDEO = "video/*"

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/multipart/MultipartBodyFactory.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/multipart/MultipartBodyFactory.kt
@@ -2,6 +2,7 @@ package com.github.kotlintelegrambot.network.multipart
 
 import com.github.kotlintelegrambot.entities.ChatId
 import com.github.kotlintelegrambot.entities.TelegramFile
+import com.github.kotlintelegrambot.entities.inputmedia.InputMediaDocument
 import com.github.kotlintelegrambot.entities.inputmedia.InputMediaPhoto
 import com.github.kotlintelegrambot.entities.inputmedia.InputMediaVideo
 import com.github.kotlintelegrambot.entities.inputmedia.MediaGroup
@@ -46,6 +47,9 @@ internal class MultipartBodyFactory(private val gson: Gson) {
 
     private fun MediaGroup.takeFiles(): List<Pair<File, String>> = medias.flatMap { groupableMedia ->
         when {
+            groupableMedia is InputMediaDocument && groupableMedia.media is TelegramFile.ByFile -> listOf(
+                groupableMedia.media.file to MediaTypeConstants.DOCUMENT
+            )
             groupableMedia is InputMediaPhoto && groupableMedia.media is TelegramFile.ByFile -> listOf(
                 groupableMedia.media.file to MediaTypeConstants.IMAGE
             )

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendMediaGroupIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendMediaGroupIT.kt
@@ -8,6 +8,7 @@ import com.github.kotlintelegrambot.entities.User
 import com.github.kotlintelegrambot.entities.files.Document
 import com.github.kotlintelegrambot.entities.inputmedia.InputMediaAudio
 import com.github.kotlintelegrambot.entities.inputmedia.InputMediaDocument
+import com.github.kotlintelegrambot.entities.inputmedia.InputMediaPhoto
 import com.github.kotlintelegrambot.entities.inputmedia.MediaGroup
 import com.github.kotlintelegrambot.entities.inputmedia.anyInputMediaPhoto
 import com.github.kotlintelegrambot.entities.inputmedia.anyInputMediaVideo
@@ -207,6 +208,26 @@ class SendMediaGroupIT : ApiClientIT() {
         val requestBody = request.body.readUtf8().trimIndent()
         val expectedRequestBody = String.format(
             getFileAsStringFromResources<SendMediaGroupIT>("sendMediaGroupRequestBody6.txt"),
+            multipartBoundary
+        ).trimIndent()
+        assertEquals(expectedRequestBody, requestBody)
+    }
+
+    @Test
+    fun `sendMediaGroup with media group composed by a document(file) with thumb and a photo(fileId)`() {
+        givenAnySendMediaGroupResponse()
+        val mediaGroup = MediaGroup.from(
+            InputMediaDocument(TelegramFile.ByFile(getFileFromResources<SendMediaGroupIT>("doc.txt"))),
+            InputMediaPhoto(TelegramFile.ByUrl(ANY_IMAGE_FILE_ID)),
+        )
+
+        sut.sendMediaGroup(ChatId.fromId(ANY_CHAT_ID), mediaGroup)
+
+        val request = mockWebServer.takeRequest()
+        val multipartBoundary = request.multipartBoundary
+        val requestBody = request.body.readUtf8().trimIndent()
+        val expectedRequestBody = String.format(
+            getFileAsStringFromResources<SendMediaGroupIT>("sendMediaGroupRequestBody7.txt"),
             multipartBoundary
         ).trimIndent()
         assertEquals(expectedRequestBody, requestBody)

--- a/telegram/src/test/resources/doc.txt
+++ b/telegram/src/test/resources/doc.txt
@@ -1,0 +1,1 @@
+This is a test document

--- a/telegram/src/test/resources/sendMediaGroupRequestBody7.txt
+++ b/telegram/src/test/resources/sendMediaGroupRequestBody7.txt
@@ -1,0 +1,17 @@
+--%1$s
+Content-Disposition: form-data; name="chat_id"
+Content-Length: 7
+
+3242424
+--%1$s
+Content-Disposition: form-data; name="media"
+Content-Length: 90
+
+[{"media":"attach://doc.txt","type":"document"},{"media":"fweo32r32nruka","type":"photo"}]
+--%1$s
+Content-Disposition: form-data; name="doc.txt"; filename="doc.txt"
+Content-Type: document/*
+Content-Length: 23
+
+This is a test document
+--%1$s--


### PR DESCRIPTION
Don't send InputMediaDocument in MediaGroup