### PR TITLE
Only consulte `Dispatcher` while update has not been consumed

### DIFF
--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Dispatcher.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/Dispatcher.kt
@@ -62,11 +62,10 @@ class Dispatcher internal constructor(
 
     private suspend fun handleUpdate(update: Update) {
         commandHandlers
+            .asSequence()
+            .filter { !update.consumed }
             .filter { it.checkUpdate(update) }
             .forEach {
-                if (update.consumed) {
-                    return
-                }
                 try {
                     it.handleUpdate(bot, update)
                 } catch (throwable: Throwable) {


### PR DESCRIPTION
Using `sequence` allows us to stop iteration whenever the update has been updated.
It is not only a performance improvement (We don't really need to iterate overall handlers) but allows us to have dynamic checks.
Let me show you an example:
Imagine a bot that has some "member/admin commands" only allowed to users that are members of a Telegram Group and/or admins from another Telegram Group.
When the update is been checked, we don't have access to the `bot` instance to be able to perform a query, and keeping a static list in some part of our code will require synchronization and extra job by handling "add/remove members" from the groups we are monitoring.
With this new change, we can have a "Global Handler" that updates some dynamic data in our code just before the rest of the handlers are checked, and those handlers can check this data within `checkUpdate()` method, something like:

```
    data class UserState(
        val isMember: Boolean,
        val isAdmin: Boolean,
    )
    val users: MutableMap<Long, UserState> = mutableMapOf()

    bot {
        dispatch {
            // Global Handler that update the global data
            message {
                this.message.from?.let { user ->
                    val isMember = bot.getChatMember(CHAT_ID, user.id).isSuccess
                    val isAdmin = bot.getChatAdministrators(CHAT_ID).getOrNull()?.any { it.user.id == user.id } ?: false
                    users[user.id] = UserState(isMember, isAdmin)
                }
            }
            // Admin Handler
            addHandler(
                object : Handler {
                    override fun checkUpdate(update: Update): Boolean =
                        update.message?.from?.let { users[it.id]?.isAdmin } ?: false

                    override suspend fun handleUpdate(bot: Bot, update: Update) {
                        // Handling it
                        update.consume()
                    }
                }
            )
            // Member Handler
            addHandler(
                object : Handler {
                    override fun checkUpdate(update: Update): Boolean =
                        update.message?.from?.let { users[it.id]?.isMember } ?: false

                    override suspend fun handleUpdate(bot: Bot, update: Update) {
                        // Handling it
                        update.consume()
                    }
                }
            )
            
            // Rest of handlers
        }
    }
```