### PR TITLE
Add `onSuccess()` and `onError()` methods to apply Side Effects to a TelegramBotResult

### DIFF
--- a/telegram/api/telegram.api
+++ b/telegram/api/telegram.api
@@ -3324,6 +3324,8 @@ public abstract class com/github/kotlintelegrambot/types/TelegramBotResult {
 	public final fun getOrNull ()Ljava/lang/Object;
 	public abstract fun isError ()Z
 	public abstract fun isSuccess ()Z
+	public final fun onError (Lkotlin/jvm/functions/Function1;)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
+	public final fun onSuccess (Lkotlin/jvm/functions/Function1;)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
 }
 
 public abstract class com/github/kotlintelegrambot/types/TelegramBotResult$Error : com/github/kotlintelegrambot/types/TelegramBotResult {

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/types/TelegramBotResult.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/types/TelegramBotResult.kt
@@ -93,4 +93,38 @@ sealed class TelegramBotResult<T> {
         is Success -> ifSuccess(value)
         is Error -> ifError(this)
     }
+
+    /**
+     * Runs the [successSideEffect] lambda function if the [TelegramBotResult] contains a successful data payload.
+     *
+     * @param successSideEffect A lambda that receives the successful data payload.
+     *
+     * @return The original instance of the [TelegramBotResult].
+     */
+    public inline fun onSuccess(
+        crossinline successSideEffect: (T) -> Unit,
+    ): TelegramBotResult<T> =
+        also {
+            when (it) {
+                is Success -> successSideEffect(it.value)
+                is Error -> Unit
+            }
+        }
+
+    /**
+     * Runs the [errorSideEffect] lambda function if the [TelegramBotResult] contains an error payload.
+     *
+     * @param errorSideEffect A lambda that receives the [Error] payload.
+     *
+     * @return The original instance of the [TelegramBotResult].
+     */
+    public inline fun onError(
+        crossinline errorSideEffect: (Error<T>) -> Unit,
+    ): TelegramBotResult<T> =
+        also {
+            when (it) {
+                is Success -> Unit
+                is Error -> errorSideEffect(it)
+            }
+        }
 }


### PR DESCRIPTION
Add `onSuccess()` and `onError()` methods to apply Side Effects to a TelegramBotResult.

It allows us to concatenate the invocation of multiple methods.

```
fun foo(): TelegramBotResult<Int> { ... }

val result = foo()
  .onSuccess {
    // The result was a success and we can apply a side effect with the value
  }
  .onError {
    // The result was an error and we can apply a side effect with the error
  }
```