### PR TITLE
No process update after stop pooling

### DIFF
--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/updater/Updater.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/updater/Updater.kt
@@ -6,6 +6,7 @@ import com.github.kotlintelegrambot.network.ApiClient
 import com.github.kotlintelegrambot.types.DispatchableObject
 import com.github.kotlintelegrambot.types.TelegramBotResult
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.yield
 
 internal class Updater(
     private val looper: Looper,
@@ -24,7 +25,7 @@ internal class Updater(
                 timeout = botTimeout,
                 allowedUpdates = null,
             )
-
+            yield()
             getUpdatesResult.fold(
                 ifSuccess = { onUpdatesReceived(it) },
                 ifError = { onErrorGettingUpdates(it) },


### PR DESCRIPTION
The "get update" endpoint has a timeout of 30 seconds. If during this period the bot is stopped, the HTTP call is ongoing and can't be canceled. After the timeout without receiving any update, the server returns an empty list of updates and they are processed even though the job where the coroutine is executed is already canceled. To avoid any wrong behavior after the bot has been already stopped, this update response should be rejected.

Fix: #293 