### PR TITLE
Improve TelegramBotResult definition

### DIFF
--- a/telegram/api/telegram.api
+++ b/telegram/api/telegram.api
@@ -3503,17 +3503,14 @@ public abstract interface class com/github/kotlintelegrambot/types/DispatchableO
 public abstract class com/github/kotlintelegrambot/types/TelegramBotResult {
 	public final fun fold (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public final fun get ()Ljava/lang/Object;
-	public final fun getOrDefault (Ljava/lang/Object;)Ljava/lang/Object;
 	public final fun getOrNull ()Ljava/lang/Object;
-	public abstract fun isError ()Z
-	public abstract fun isSuccess ()Z
+	public final fun isError ()Z
+	public final fun isSuccess ()Z
 	public final fun onError (Lkotlin/jvm/functions/Function1;)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
 	public final fun onSuccess (Lkotlin/jvm/functions/Function1;)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
 }
 
 public abstract class com/github/kotlintelegrambot/types/TelegramBotResult$Error : com/github/kotlintelegrambot/types/TelegramBotResult {
-	public fun isError ()Z
-	public fun isSuccess ()Z
 }
 
 public final class com/github/kotlintelegrambot/types/TelegramBotResult$Error$HttpError : com/github/kotlintelegrambot/types/TelegramBotResult$Error {
@@ -3576,9 +3573,11 @@ public final class com/github/kotlintelegrambot/types/TelegramBotResult$Success 
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getValue ()Ljava/lang/Object;
 	public fun hashCode ()I
-	public fun isError ()Z
-	public fun isSuccess ()Z
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/kotlintelegrambot/types/TelegramBotResultKt {
+	public static final fun getOrDefault (Lcom/github/kotlintelegrambot/types/TelegramBotResult;Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/github/kotlintelegrambot/webhook/WebhookConfig {

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -1375,7 +1375,7 @@ internal class ApiClient(
         customTitle,
     ).runApiOperation()
 
-    private fun <T> Call<Response<T>>.runApiOperation(): TelegramBotResult<T> {
+    private fun <T : Any> Call<Response<T>>.runApiOperation(): TelegramBotResult<T> {
         val apiResponse = try {
             apiRequestSender.send(this)
         } catch (exception: Exception) {

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiResponseMapper.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiResponseMapper.kt
@@ -4,7 +4,7 @@ import com.github.kotlintelegrambot.types.TelegramBotResult
 
 internal class ApiResponseMapper {
 
-    fun <T> mapToTelegramBotResult(apiResponse: CallResponse<Response<T>>): TelegramBotResult<T> {
+    fun <T : Any> mapToTelegramBotResult(apiResponse: CallResponse<Response<T>>): TelegramBotResult<T> {
         fun invalidResponse() = TelegramBotResult.Error.InvalidResponse(
             apiResponse.code(),
             apiResponse.message(),

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/types/TelegramBotResult.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/types/TelegramBotResult.kt
@@ -1,80 +1,65 @@
 package com.github.kotlintelegrambot.types
 
 import com.github.kotlintelegrambot.network.Response
+import com.github.kotlintelegrambot.types.TelegramBotResult.Success
 import java.lang.Exception
 
 /**
  * Union type representing the execution result of a Telegram Bot operation.
  * It will be either a success [Success] or an error [Error]
  */
-sealed class TelegramBotResult<T> {
+sealed class TelegramBotResult<out T : Any> {
 
     /**
      * Returns True if this a [Success] and False otherwise. Added for flexibility, but the use
      * of [fold] is recommended instead.
      */
-    abstract val isSuccess: Boolean
+    val isSuccess: Boolean
+        inline get() = this is Success
 
     /**
      * Returns True if this an [Error] and False otherwise. Added for flexibility, but the use
      * of [fold] is recommended instead.
      */
-    abstract val isError: Boolean
+    val isError: Boolean
+        inline get() = this !is Success
 
     /**
      * Represents a Telegram Bot Api successful response.
      */
-    data class Success<T>(val value: T) : TelegramBotResult<T>() {
+    data class Success<out T : Any>(val value: T) : TelegramBotResult<T>()
 
-        override val isSuccess: Boolean
-            get() = true
-
-        override val isError: Boolean
-            get() = false
-    }
-
-    sealed class Error<T> : TelegramBotResult<T>() {
-
-        override val isSuccess: Boolean
-            get() = false
-
-        override val isError: Boolean
-            get() = true
+    sealed class Error : TelegramBotResult<Nothing>() {
 
         /**
          * Represents an HTTP error.
          */
-        data class HttpError<T>(val httpCode: Int, val description: String?) : Error<T>()
+        data class HttpError(val httpCode: Int, val description: String?) : Error()
 
         /**
          * Represents a Telegram Bot Api error response.
          */
-        data class TelegramApi<T>(val errorCode: Int, val description: String) : Error<T>()
+        data class TelegramApi(val errorCode: Int, val description: String) : Error()
 
         /**
          * Represents a response error that can't be mapped to a Telegram Bot Api error response.
          */
-        data class InvalidResponse<T>(
+        data class InvalidResponse(
             val httpCode: Int,
             val httpStatusMessage: String?,
-            val body: Response<T>?,
-        ) : Error<T>()
+            val body: Response<*>?,
+        ) : Error()
 
         /**
          * Wraps any exception thrown while executing and processing an api call.
          */
-        data class Unknown<T>(val exception: Exception) : Error<T>()
+        data class Unknown(val exception: Exception) : Error()
     }
 
     /**
      * Returns the [Success] value if available, otherwise null.
      */
     fun getOrNull(): T? = if (this is Success) value else null
-
-    /**
-     * Returns the [Success] value if available, otherwise [default].
-     */
-    fun getOrDefault(default: T): T = if (this is Success) value else default
 
     /**
      * Returns the [Success] value if available, otherwise throws an exception.
@@ -89,7 +74,7 @@ sealed class TelegramBotResult<T> {
      *
      * @return the result of applying the correspondent function.
      */
-    inline fun <R> fold(ifSuccess: (T) -> R, ifError: (Error<T>) -> R): R = when (this) {
+    inline fun <R> fold(ifSuccess: (T) -> R, ifError: (Error) -> R): R = when (this) {
         is Success -> ifSuccess(value)
         is Error -> ifError(this)
     }
@@ -119,7 +104,7 @@ sealed class TelegramBotResult<T> {
      * @return The original instance of the [TelegramBotResult].
      */
     public inline fun onError(
-        crossinline errorSideEffect: (Error<T>) -> Unit,
+        crossinline errorSideEffect: (Error) -> Unit,
     ): TelegramBotResult<T> =
         also {
             when (it) {
@@ -128,3 +113,8 @@ sealed class TelegramBotResult<T> {
             }
         }
 }
+
+/**
+ * Returns the [Success] value if available, otherwise [default].
+ */
+infix fun <A : Any> TelegramBotResult<A>.getOrDefault(default: A): A = if (this is Success) value else default

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/updater/Updater.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/updater/Updater.kt
@@ -49,7 +49,7 @@ internal class Updater(
         lastUpdateId = updates.last().updateId + 1
     }
 
-    private suspend fun onErrorGettingUpdates(error: TelegramBotResult.Error<List<Update>>) {
+    private suspend fun onErrorGettingUpdates(error: TelegramBotResult.Error) {
         val errorDescription: String? = when (error) {
             is TelegramBotResult.Error.HttpError -> "${error.httpCode} ${error.description}"
             is TelegramBotResult.Error.TelegramApi -> "${error.errorCode} ${error.description}"

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/ApiResponseMapperTest.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/ApiResponseMapperTest.kt
@@ -18,7 +18,7 @@ class ApiResponseMapperTest {
 
         val telegramBotResult = sut.mapToTelegramBotResult(notSuccessfulResponse)
 
-        val expectedTelegramBotResult = TelegramBotResult.Error.HttpError<Int>(
+        val expectedTelegramBotResult = TelegramBotResult.Error.HttpError(
             ANY_HTTP_ERROR_CODE,
             ANY_ERROR_BODY,
         )
@@ -31,7 +31,7 @@ class ApiResponseMapperTest {
 
         val telegramBotResult = sut.mapToTelegramBotResult(successfulResponseWithNoBody)
 
-        val expectedTelegramBotResult = TelegramBotResult.Error.InvalidResponse<Int>(
+        val expectedTelegramBotResult = TelegramBotResult.Error.InvalidResponse(
             200,
             "OK",
             null,
@@ -147,7 +147,7 @@ class ApiResponseMapperTest {
             successfulResponseWithValidErrorTgResponse,
         )
 
-        val expectedTelegramBotResult = TelegramBotResult.Error.TelegramApi<Int>(
+        val expectedTelegramBotResult = TelegramBotResult.Error.TelegramApi(
             ANY_ERROR_CODE,
             ANY_ERROR_DESCRIPTION,
         )

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/types/TelegramBotResultTest.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/types/TelegramBotResultTest.kt
@@ -14,7 +14,7 @@ import java.lang.IllegalStateException
 class TelegramBotResultTest {
 
     private val successSideEfect = mockk<(Int) -> Unit>(relaxed = true)
-    private val errorSideEfect = mockk<(TelegramBotResult.Error<Int>) -> Unit>(relaxed = true)
+    private val errorSideEfect = mockk<(TelegramBotResult.Error) -> Unit>(relaxed = true)
 
     @Test
     fun `getOrNull with a success`() {
@@ -26,7 +26,7 @@ class TelegramBotResultTest {
 
     @Test
     fun `getOrNull with an error`() {
-        val error = TelegramBotResult.Error.Unknown<Int>(Exception())
+        val error = TelegramBotResult.Error.Unknown(Exception())
 
         assertNull(error.getOrNull())
     }
@@ -41,7 +41,7 @@ class TelegramBotResultTest {
 
     @Test
     fun `get with an error`() {
-        val error = TelegramBotResult.Error.Unknown<Int>(Exception())
+        val error = TelegramBotResult.Error.Unknown(Exception())
 
         assertThrows<IllegalStateException> {
             error.get()
@@ -60,7 +60,7 @@ class TelegramBotResultTest {
     @Test
     fun `getOrDefault with an error`() {
         val default = 55
-        val error = TelegramBotResult.Error.Unknown<Int>(Exception())
+        val error = TelegramBotResult.Error.Unknown(Exception())
 
         assertEquals(default, error.getOrDefault(default))
     }
@@ -70,7 +70,7 @@ class TelegramBotResultTest {
         val success = TelegramBotResult.Success(1)
         assertTrue(success.isSuccess)
 
-        val error = TelegramBotResult.Error.Unknown<Int>(Exception())
+        val error = TelegramBotResult.Error.Unknown(Exception())
         assertFalse(error.isSuccess)
     }
 
@@ -79,7 +79,7 @@ class TelegramBotResultTest {
         val success = TelegramBotResult.Success(1)
         assertFalse(success.isError)
 
-        val error = TelegramBotResult.Error.Unknown<Int>(Exception())
+        val error = TelegramBotResult.Error.Unknown(Exception())
         assertTrue(error.isError)
     }
 
@@ -99,9 +99,9 @@ class TelegramBotResultTest {
 
     @Test
     fun `fold if error`() {
-        val error = TelegramBotResult.Error.HttpError<Int>(400, "WTF")
+        val error = TelegramBotResult.Error.HttpError(400, "WTF")
 
-        val fError: (error: TelegramBotResult.Error<Int>) -> Pair<Int, String?>? = {
+        val fError: (error: TelegramBotResult.Error) -> Pair<Int, String?>? = {
             if (it is TelegramBotResult.Error.HttpError) {
                 it.httpCode to it.description
             } else {
@@ -128,7 +128,7 @@ class TelegramBotResultTest {
 
     @Test
     fun `onSuccess shouldn't be invoked when it is an error TelegramBotResult`() {
-        val error = TelegramBotResult.Error.HttpError<Int>(400, "WTF")
+        val error = TelegramBotResult.Error.HttpError(400, "WTF")
 
         error.onSuccess(successSideEfect)
 
@@ -147,7 +147,7 @@ class TelegramBotResultTest {
 
     @Test
     fun `onError should be invoked when it is an error TelegramBotResult`() {
-        val error = TelegramBotResult.Error.HttpError<Int>(400, "WTF")
+        val error = TelegramBotResult.Error.HttpError(400, "WTF")
 
         error.onError(errorSideEfect)
 

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/updater/UpdaterTest.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/updater/UpdaterTest.kt
@@ -57,10 +57,10 @@ class UpdaterTest {
     fun `updates pagination in polling with only errors`() = runTest {
         val looper = BoundLooper(StandardTestDispatcher(testScheduler))
         val sut = createUpdater(looper)
-        val error1 = TelegramBotResult.Error.Unknown<List<Update>>(Exception())
-        val error2 = TelegramBotResult.Error.HttpError<List<Update>>(400, "Not found")
-        val error3 = TelegramBotResult.Error.TelegramApi<List<Update>>(523, "WAT")
-        val error4 = TelegramBotResult.Error.InvalidResponse<List<Update>>(521, "WUT", null)
+        val error1 = TelegramBotResult.Error.Unknown(Exception())
+        val error2 = TelegramBotResult.Error.HttpError(400, "Not found")
+        val error3 = TelegramBotResult.Error.TelegramApi(523, "WAT")
+        val error4 = TelegramBotResult.Error.InvalidResponse(521, "WUT", null)
         givenGetUpdatesResults(
             error1,
             error2,
@@ -84,9 +84,9 @@ class UpdaterTest {
     fun `updates pagination in polling with mixed successes and errors`() = runTest {
         val looper = BoundLooper(StandardTestDispatcher(testScheduler))
         val sut = createUpdater(looper)
-        val error1 = TelegramBotResult.Error.Unknown<List<Update>>(Exception())
+        val error1 = TelegramBotResult.Error.Unknown(Exception())
         val updates1 = (1L until 3).map { anyUpdate(updateId = it) }
-        val error2 = TelegramBotResult.Error.HttpError<List<Update>>(400, "Not found")
+        val error2 = TelegramBotResult.Error.HttpError(400, "Not found")
         val updates2 = emptyList<Update>()
         val updates3 = (3L until 6).map { anyUpdate(updateId = it) }
         givenGetUpdatesResults(
@@ -139,9 +139,9 @@ class UpdaterTest {
     fun `queue updates and errors in polling with mixed successes and errors`() = runTest {
         val looper = BoundLooper(StandardTestDispatcher(testScheduler))
         val sut = createUpdater(looper)
-        val error1 = TelegramBotResult.Error.Unknown<List<Update>>(Exception("I'm exceptional"))
+        val error1 = TelegramBotResult.Error.Unknown(Exception("I'm exceptional"))
         val updates1 = (1L until 3).map { anyUpdate(updateId = it) }
-        val error2 = TelegramBotResult.Error.HttpError<List<Update>>(400, "Not found")
+        val error2 = TelegramBotResult.Error.HttpError(400, "Not found")
         val updates2 = emptyList<Update>()
         val updates3 = (3L until 6).map { anyUpdate(updateId = it) }
         givenGetUpdatesResults(
@@ -174,10 +174,10 @@ class UpdaterTest {
     fun `queue error in polling with only errors`() = runTest {
         val looper = BoundLooper(StandardTestDispatcher(testScheduler))
         val sut = createUpdater(looper)
-        val error1 = TelegramBotResult.Error.Unknown<List<Update>>(Exception("I'm exceptional"))
-        val error2 = TelegramBotResult.Error.HttpError<List<Update>>(400, "Not found")
-        val error3 = TelegramBotResult.Error.TelegramApi<List<Update>>(523, "WAT")
-        val error4 = TelegramBotResult.Error.InvalidResponse<List<Update>>(521, "WUT", null)
+        val error1 = TelegramBotResult.Error.Unknown(Exception("I'm exceptional"))
+        val error2 = TelegramBotResult.Error.HttpError(400, "Not found")
+        val error3 = TelegramBotResult.Error.TelegramApi(523, "WAT")
+        val error4 = TelegramBotResult.Error.InvalidResponse(521, "WUT", null)
         givenGetUpdatesResults(
             error1,
             error2,


### PR DESCRIPTION
The TelegramBotRestul.Error implementation doesn't need to declare "the success type", because it is not used at all when it is an error instance