### PR TITLE
Configure project to be runnable on modern java versions

### DIFF
--- a/telegram/build.gradle
+++ b/telegram/build.gradle
@@ -54,11 +54,16 @@ sourceSets {
 }
 
 compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 test {


### PR DESCRIPTION
## Problem description

Running the project on the machine with Java 20 installed leads to the error

```
FAILURE: Build failed with an exception.
  java.lang.IllegalArgumentException: Unsupported class file major version 64
```

This happens because the Java target is set silently (to Java 20) and Kotlin is set explicitly to 1.8.

## PR purpose

PR fixes this issue setting the Java target explicitly to 1.8.

### What has been done

- Added `java { }` section to configure target and source compatibility for Java, not only for Kotlin
- Changed hardcoded strings `"1.8"` to the constant provided by Gradle Api

## Compatibility note

This PR itself won't enable running the project on the machine with Java 20 installed. Because the current Gradle version used in the project (`7.2`) doesn't support this Java version.
Here is the [Compatibility Matrix](https://docs.gradle.org/current/userguide/compatibility.html#java). Due to this matrix, this PR will make it possible to run the project on machines with Java up to 15.

Merging current PR and [this PR](https://github.com/kotlin-telegram-bot/kotlin-telegram-bot/pull/304) will make the project compatible with Java up to 20.