### PR TITLE
Bump library version to 6.1.0

### DIFF
--- a/telegram/build.gradle
+++ b/telegram/build.gradle
@@ -17,7 +17,7 @@ plugins {
 apply plugin: 'kotlin'
 
 group 'com.github.kotlintelegrambot'
-version '6.0.7'
+version '6.1.0'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
The library was released but the version wasn't bumped for some reason.
This PR bumps the version.

Note: Please close this PR if the bump wasn't done on purpose.
I'll appreciate it if you describe why it shouldn't be bumped.