### PR TITLE
Keep Handler publicly available

### DIFF
--- a/telegram/api/telegram.api
+++ b/telegram/api/telegram.api
@@ -281,6 +281,12 @@ public final class com/github/kotlintelegrambot/dispatcher/handlers/ChannelHandl
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/github/kotlintelegrambot/dispatcher/handlers/ChatMemberHandler : com/github/kotlintelegrambot/dispatcher/handlers/Handler {
+	public fun <init> (Lkotlin/jvm/functions/Function2;)V
+	public fun checkUpdate (Lcom/github/kotlintelegrambot/entities/Update;)Z
+	public fun handleUpdate (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class com/github/kotlintelegrambot/dispatcher/handlers/ChatMemberHandlerEnvironment {
 	public fun <init> (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/ChatMemberUpdated;)V
 	public final fun component1 ()Lcom/github/kotlintelegrambot/Bot;

--- a/telegram/api/telegram.api
+++ b/telegram/api/telegram.api
@@ -481,6 +481,12 @@ public final class com/github/kotlintelegrambot/dispatcher/handlers/MessageHandl
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/github/kotlintelegrambot/dispatcher/handlers/MyChatMemberHandler : com/github/kotlintelegrambot/dispatcher/handlers/Handler {
+	public fun <init> (Lkotlin/jvm/functions/Function2;)V
+	public fun checkUpdate (Lcom/github/kotlintelegrambot/entities/Update;)Z
+	public fun handleUpdate (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class com/github/kotlintelegrambot/dispatcher/handlers/MyChatMemberHandlerEnvironment {
 	public fun <init> (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/Update;Lcom/github/kotlintelegrambot/entities/ChatMemberUpdated;)V
 	public final fun component1 ()Lcom/github/kotlintelegrambot/Bot;

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/ChatMemberHandler.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/ChatMemberHandler.kt
@@ -10,7 +10,7 @@ data class ChatMemberHandlerEnvironment(
     val chatMember: ChatMemberUpdated,
 )
 
-internal class ChatMemberHandler(
+class ChatMemberHandler(
     private val handleChatMember: HandleChatMember,
 ) : Handler {
     override fun checkUpdate(update: Update): Boolean = update.chatMember != null

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/MyChatMemberHandler.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/MyChatMemberHandler.kt
@@ -10,7 +10,7 @@ data class MyChatMemberHandlerEnvironment(
     val myChatMember: ChatMemberUpdated,
 )
 
-internal class MyChatMemberHandler(
+class MyChatMemberHandler(
     private val handleMyChatMember: HandleMyChatMember,
 ) : Handler {
     override fun checkUpdate(update: Update): Boolean = update.myChatMember != null


### PR DESCRIPTION
Keep the new `MyChatMemberHandler` and `ChatMemberHandler` publicly available as we defined on #286