### PR TITLE
Implement 'setMessageReaction' Telegram API method

### DIFF
--- a/telegram/api/telegram.api
+++ b/telegram/api/telegram.api
@@ -150,6 +150,8 @@ public final class com/github/kotlintelegrambot/Bot {
 	public final fun setChatPhoto (Lcom/github/kotlintelegrambot/entities/ChatId;Ljava/io/File;)Lkotlin/Pair;
 	public final fun setChatStickerSet (Lcom/github/kotlintelegrambot/entities/ChatId;Ljava/lang/String;)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
 	public final fun setChatTitle (Lcom/github/kotlintelegrambot/entities/ChatId;Ljava/lang/String;)Lkotlin/Pair;
+	public final fun setMessageReaction (Lcom/github/kotlintelegrambot/entities/ChatId;JLjava/util/List;Z)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
+	public static synthetic fun setMessageReaction$default (Lcom/github/kotlintelegrambot/Bot;Lcom/github/kotlintelegrambot/entities/ChatId;JLjava/util/List;ZILjava/lang/Object;)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
 	public final fun setMyCommands (Ljava/util/List;)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
 	public final fun setStickerPositionInSet (Ljava/lang/String;I)Lkotlin/Pair;
 	public final fun setWebhook (Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/TelegramFile;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;)Lkotlin/Pair;
@@ -3216,6 +3218,33 @@ public final class com/github/kotlintelegrambot/entities/polls/PollType : java/l
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/github/kotlintelegrambot/entities/polls/PollType;
 	public static fun values ()[Lcom/github/kotlintelegrambot/entities/polls/PollType;
+}
+
+public abstract class com/github/kotlintelegrambot/entities/reaction/ReactionType {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getType ()Ljava/lang/String;
+}
+
+public final class com/github/kotlintelegrambot/entities/reaction/ReactionType$Custom : com/github/kotlintelegrambot/entities/reaction/ReactionType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/github/kotlintelegrambot/entities/reaction/ReactionType$Custom;
+	public static synthetic fun copy$default (Lcom/github/kotlintelegrambot/entities/reaction/ReactionType$Custom;Ljava/lang/String;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/entities/reaction/ReactionType$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustomEmojiId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/kotlintelegrambot/entities/reaction/ReactionType$Emoji : com/github/kotlintelegrambot/entities/reaction/ReactionType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/github/kotlintelegrambot/entities/reaction/ReactionType$Emoji;
+	public static synthetic fun copy$default (Lcom/github/kotlintelegrambot/entities/reaction/ReactionType$Emoji;Ljava/lang/String;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/entities/reaction/ReactionType$Emoji;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEmoji ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/github/kotlintelegrambot/entities/stickers/MaskPosition {

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -24,6 +24,7 @@ import com.github.kotlintelegrambot.entities.payments.PaymentInvoiceInfo
 import com.github.kotlintelegrambot.entities.payments.ShippingOption
 import com.github.kotlintelegrambot.entities.polls.Poll
 import com.github.kotlintelegrambot.entities.polls.PollType
+import com.github.kotlintelegrambot.entities.reaction.ReactionType
 import com.github.kotlintelegrambot.entities.stickers.MaskPosition
 import com.github.kotlintelegrambot.logging.LogLevel
 import com.github.kotlintelegrambot.network.ApiClient
@@ -2124,5 +2125,17 @@ class Bot private constructor(
         chatId,
         userId,
         customTitle,
+    )
+
+    fun setMessageReaction(
+        chatId: ChatId,
+        messageId: Long,
+        reaction: List<ReactionType>,
+        isBig: Boolean = false,
+    ): TelegramBotResult<Boolean> = apiClient.setMessageReaction(
+        chatId = chatId,
+        messageId = messageId,
+        reaction = reaction,
+        isBig = isBig,
     )
 }

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/reaction/ReactionType.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/reaction/ReactionType.kt
@@ -1,0 +1,20 @@
+package com.github.kotlintelegrambot.entities.reaction
+
+import com.google.gson.annotations.SerializedName
+
+sealed class ReactionType(
+    val type: String,
+) {
+
+    data class Emoji(
+        val emoji: String,
+    ) : ReactionType(
+        "emoji",
+    )
+
+    data class Custom(
+        @SerializedName("custom_emoji_id") val customEmojiId: String,
+    ) : ReactionType(
+        "custom_emoji",
+    )
+}

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -31,6 +31,7 @@ import com.github.kotlintelegrambot.entities.payments.LabeledPrice
 import com.github.kotlintelegrambot.entities.payments.ShippingOption
 import com.github.kotlintelegrambot.entities.polls.Poll
 import com.github.kotlintelegrambot.entities.polls.PollType
+import com.github.kotlintelegrambot.entities.reaction.ReactionType
 import com.github.kotlintelegrambot.entities.stickers.MaskPosition
 import com.github.kotlintelegrambot.entities.stickers.StickerSet
 import com.github.kotlintelegrambot.logging.LogLevel
@@ -1447,6 +1448,20 @@ internal class ApiClient(
         userId,
         customTitle,
     ).runApiOperation()
+
+    fun setMessageReaction(
+        chatId: ChatId,
+        messageId: Long,
+        reaction: List<ReactionType>,
+        isBig: Boolean,
+    ): TelegramBotResult<Boolean> {
+        return service.setMessageReaction(
+            chatId = chatId,
+            messageId = messageId,
+            reaction = gson.toJson(reaction),
+            isBig = isBig,
+        ).runApiOperation()
+    }
 
     private fun <T : Any> Call<Response<T>>.runApiOperation(): TelegramBotResult<T> {
         val apiResponse = try {

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
@@ -953,6 +953,15 @@ internal interface ApiService {
         @Field(ApiConstants.USER_ID) userId: Long,
         @Field(ApiConstants.SetChatAdministratorCustomTitle.CUSTOM_TITLE) customTitle: String,
     ): Call<Response<Boolean>>
+
+    @FormUrlEncoded
+    @POST("setMessageReaction")
+    fun setMessageReaction(
+        @Field(ApiConstants.CHAT_ID) chatId: ChatId,
+        @Field("message_id") messageId: Long,
+        @Field("reaction") reaction: String?,
+        @Field("is_big") isBig: Boolean?,
+    ): Call<Response<Boolean>>
 }
 
 class LabeledPriceList(private val labeledPrice: List<LabeledPrice>) {

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/serialization/GsonFactory.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/serialization/GsonFactory.kt
@@ -6,11 +6,13 @@ import com.github.kotlintelegrambot.entities.inlinequeryresults.InlineQueryResul
 import com.github.kotlintelegrambot.entities.inputmedia.GroupableMedia
 import com.github.kotlintelegrambot.entities.inputmedia.InputMedia
 import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton
+import com.github.kotlintelegrambot.entities.reaction.ReactionType
 import com.github.kotlintelegrambot.network.serialization.adapter.DiceEmojiAdapter
 import com.github.kotlintelegrambot.network.serialization.adapter.GroupableMediaAdapter
 import com.github.kotlintelegrambot.network.serialization.adapter.InlineKeyboardButtonAdapter
 import com.github.kotlintelegrambot.network.serialization.adapter.InlineQueryResultAdapter
 import com.github.kotlintelegrambot.network.serialization.adapter.InputMediaAdapter
+import com.github.kotlintelegrambot.network.serialization.adapter.ReactionTypeAdapter
 import com.github.kotlintelegrambot.network.serialization.adapter.TelegramFileAdapter
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
@@ -25,6 +27,7 @@ internal object GsonFactory {
         .registerTypeAdapter(TelegramFile::class.java, TelegramFileAdapter())
         .registerTypeAdapter(InputMedia::class.java, InputMediaAdapter())
         .registerTypeAdapter(GroupableMedia::class.java, GroupableMediaAdapter(InputMediaAdapter()))
+        .registerTypeAdapter(ReactionType::class.java, ReactionTypeAdapter())
         .create()
 
     fun createForMultipartBodyFactory(): Gson = GsonBuilder()

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/serialization/adapter/ReactionTypeAdapter.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/serialization/adapter/ReactionTypeAdapter.kt
@@ -1,0 +1,19 @@
+package com.github.kotlintelegrambot.network.serialization.adapter
+
+import com.github.kotlintelegrambot.entities.reaction.ReactionType
+import com.google.gson.JsonElement
+import com.google.gson.JsonSerializationContext
+import com.google.gson.JsonSerializer
+import java.lang.reflect.Type
+
+internal class ReactionTypeAdapter : JsonSerializer<ReactionType> {
+
+    override fun serialize(
+        src: ReactionType,
+        typeOfSrc: Type,
+        context: JsonSerializationContext,
+    ): JsonElement = when (src) {
+        is ReactionType.Custom -> context.serialize(src, ReactionType.Custom::class.java)
+        is ReactionType.Emoji -> context.serialize(src, ReactionType.Emoji::class.java)
+    }
+}


### PR DESCRIPTION
## Description

Implementation of Telegram API [setMessageReaction](https://core.telegram.org/bots/api#setmessagereaction).

## Testing

I haven't added unit tests here as from my point of view there is no sense to test mocked API response.  
But if the tests are required I can cover code with something similar to [SendDiceIT](https://github.com/kotlin-telegram-bot/kotlin-telegram-bot/blob/main/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SendDiceIT.kt) and [DiceEmojiAdapterTest](https://github.com/kotlin-telegram-bot/kotlin-telegram-bot/blob/main/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/serialization/adapter/DiceEmojiAdapterTest.kt)

- [x] Build the library locally and use it as a jar in the test project