### PR TITLE
GH-323 expose secret token for the webhook configuration

### DIFF
--- a/telegram/api/telegram.api
+++ b/telegram/api/telegram.api
@@ -3708,7 +3708,7 @@ public final class com/github/kotlintelegrambot/webhook/WebhookConfig {
 	public final fun component5 ()Ljava/lang/Integer;
 	public final fun component6 ()Ljava/util/List;
 	public final fun component7 ()Ljava/lang/Boolean;
-	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
 	public final fun copy (ZLjava/lang/String;Lcom/github/kotlintelegrambot/entities/TelegramFile;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;)Lcom/github/kotlintelegrambot/webhook/WebhookConfig;
 	public static synthetic fun copy$default (Lcom/github/kotlintelegrambot/webhook/WebhookConfig;ZLjava/lang/String;Lcom/github/kotlintelegrambot/entities/TelegramFile;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/webhook/WebhookConfig;
 	public fun equals (Ljava/lang/Object;)Z

--- a/telegram/api/telegram.api
+++ b/telegram/api/telegram.api
@@ -152,8 +152,8 @@ public final class com/github/kotlintelegrambot/Bot {
 	public final fun setChatTitle (Lcom/github/kotlintelegrambot/entities/ChatId;Ljava/lang/String;)Lkotlin/Pair;
 	public final fun setMyCommands (Ljava/util/List;)Lcom/github/kotlintelegrambot/types/TelegramBotResult;
 	public final fun setStickerPositionInSet (Ljava/lang/String;I)Lkotlin/Pair;
-	public final fun setWebhook (Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/TelegramFile;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;)Lkotlin/Pair;
-	public static synthetic fun setWebhook$default (Lcom/github/kotlintelegrambot/Bot;Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/TelegramFile;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lkotlin/Pair;
+	public final fun setWebhook (Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/TelegramFile;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;)Lkotlin/Pair;
+	public static synthetic fun setWebhook$default (Lcom/github/kotlintelegrambot/Bot;Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/TelegramFile;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;ILjava/lang/Object;)Lkotlin/Pair;
 	public final fun startPolling ()V
 	public final fun startWebhook ()Z
 	public final fun stopMessageLiveLocation (Lcom/github/kotlintelegrambot/entities/ChatId;Ljava/lang/Long;Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/ReplyMarkup;)Lkotlin/Pair;
@@ -3668,22 +3668,24 @@ public final class com/github/kotlintelegrambot/types/TelegramBotResultKt {
 }
 
 public final class com/github/kotlintelegrambot/webhook/WebhookConfig {
-	public fun <init> (Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/TelegramFile;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/TelegramFile;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/TelegramFile;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/TelegramFile;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lcom/github/kotlintelegrambot/entities/TelegramFile;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/Integer;
 	public final fun component5 ()Ljava/util/List;
 	public final fun component6 ()Ljava/lang/Boolean;
-	public final fun copy (Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/TelegramFile;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;)Lcom/github/kotlintelegrambot/webhook/WebhookConfig;
-	public static synthetic fun copy$default (Lcom/github/kotlintelegrambot/webhook/WebhookConfig;Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/TelegramFile;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/webhook/WebhookConfig;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/TelegramFile;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;)Lcom/github/kotlintelegrambot/webhook/WebhookConfig;
+	public static synthetic fun copy$default (Lcom/github/kotlintelegrambot/webhook/WebhookConfig;Ljava/lang/String;Lcom/github/kotlintelegrambot/entities/TelegramFile;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;ILjava/lang/Object;)Lcom/github/kotlintelegrambot/webhook/WebhookConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllowedUpdates ()Ljava/util/List;
 	public final fun getCertificate ()Lcom/github/kotlintelegrambot/entities/TelegramFile;
 	public final fun getDropPendingUpdates ()Ljava/lang/Boolean;
 	public final fun getIpAddress ()Ljava/lang/String;
 	public final fun getMaxConnections ()Ljava/lang/Integer;
+	public final fun getSecretToken ()Ljava/lang/String;
 	public final fun getUrl ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -3696,12 +3698,14 @@ public final class com/github/kotlintelegrambot/webhook/WebhookConfigBuilder {
 	public final fun getDropPendingUpdates ()Ljava/lang/Boolean;
 	public final fun getIpAddress ()Ljava/lang/String;
 	public final fun getMaxConnections ()Ljava/lang/Integer;
+	public final fun getSecretToken ()Ljava/lang/String;
 	public final fun getUrl ()Ljava/lang/String;
 	public final fun setAllowedUpdates (Ljava/util/List;)V
 	public final fun setCertificate (Lcom/github/kotlintelegrambot/entities/TelegramFile;)V
 	public final fun setDropPendingUpdates (Ljava/lang/Boolean;)V
 	public final fun setIpAddress (Ljava/lang/String;)V
 	public final fun setMaxConnections (Ljava/lang/Integer;)V
+	public final fun setSecretToken (Ljava/lang/String;)V
 	public final fun setUrl (Ljava/lang/String;)V
 }
 

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -137,6 +137,7 @@ class Bot private constructor(
             webhookConfig.maxConnections,
             webhookConfig.allowedUpdates,
             webhookConfig.dropPendingUpdates,
+            webhookConfig.secretToken
         )
         val webhookSet = setWebhookResult.bimap(
             mapResponse = { true },
@@ -212,7 +213,8 @@ class Bot private constructor(
         maxConnections: Int? = null,
         allowedUpdates: List<String>? = null,
         dropPendingUpdates: Boolean? = null,
-    ) = apiClient.setWebhook(url, certificate, ipAddress, maxConnections, allowedUpdates, dropPendingUpdates).call()
+        secretToken: String? = null,
+    ) = apiClient.setWebhook(url, certificate, ipAddress, maxConnections, allowedUpdates, dropPendingUpdates, secretToken).call()
 
     fun deleteWebhook(
         dropPendingUpdates: Boolean? = null,

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -137,7 +137,7 @@ class Bot private constructor(
             webhookConfig.maxConnections,
             webhookConfig.allowedUpdates,
             webhookConfig.dropPendingUpdates,
-            webhookConfig.secretToken
+            webhookConfig.secretToken,
         )
         val webhookSet = setWebhookResult.bimap(
             mapResponse = { true },

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -181,7 +181,7 @@ internal class ApiClient(
             maxConnections = maxConnections,
             allowedUpdates = allowedUpdates,
             dropPendingUpdates = dropPendingUpdates,
-            secretToken = secretToken
+            secretToken = secretToken,
         )
     }
 

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -127,6 +127,7 @@ internal class ApiClient(
         maxConnections: Int? = null,
         allowedUpdates: List<String>? = null,
         dropPendingUpdates: Boolean? = null,
+        secretToken: String? = null,
     ): Call<Response<Boolean>> = when (certificate) {
         is ByFileId -> service.setWebhookWithCertificateAsFileId(
             url = url,
@@ -135,6 +136,7 @@ internal class ApiClient(
             maxConnections = maxConnections,
             allowedUpdates = allowedUpdates,
             dropPendingUpdates = dropPendingUpdates,
+            secretToken = secretToken,
         )
 
         is ByUrl -> service.setWebhookWithCertificateAsFileUrl(
@@ -144,6 +146,7 @@ internal class ApiClient(
             maxConnections = maxConnections,
             allowedUpdates = allowedUpdates,
             dropPendingUpdates = dropPendingUpdates,
+            secretToken = secretToken,
         )
 
         is ByFile -> service.setWebhookWithCertificateAsFile(
@@ -156,6 +159,7 @@ internal class ApiClient(
             maxConnections = maxConnections?.toMultipartBodyPart(ApiConstants.SetWebhook.MAX_CONNECTIONS),
             allowedUpdates = allowedUpdates?.toMultipartBodyPart(ApiConstants.SetWebhook.ALLOWED_UPDATES),
             dropPendingUpdates = dropPendingUpdates?.toMultipartBodyPart(ApiConstants.SetWebhook.DROP_PENDING_UPDATES),
+            secretToken = secretToken?.toMultipartBodyPart(ApiConstants.SetWebhook.SECRET_TOKEN),
         )
 
         is ByByteArray -> service.setWebhookWithCertificateAsFile(
@@ -168,6 +172,7 @@ internal class ApiClient(
             maxConnections = maxConnections?.toMultipartBodyPart(ApiConstants.SetWebhook.MAX_CONNECTIONS),
             allowedUpdates = allowedUpdates?.toMultipartBodyPart(ApiConstants.SetWebhook.ALLOWED_UPDATES),
             dropPendingUpdates = dropPendingUpdates?.toMultipartBodyPart(ApiConstants.SetWebhook.DROP_PENDING_UPDATES),
+            secretToken = secretToken?.toMultipartBodyPart(ApiConstants.SetWebhook.SECRET_TOKEN),
         )
 
         null -> service.setWebhook(
@@ -176,6 +181,7 @@ internal class ApiClient(
             maxConnections = maxConnections,
             allowedUpdates = allowedUpdates,
             dropPendingUpdates = dropPendingUpdates,
+            secretToken = secretToken
         )
     }
 

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiConstants.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiConstants.kt
@@ -25,6 +25,7 @@ internal object ApiConstants {
         const val MAX_CONNECTIONS = "max_connections"
         const val ALLOWED_UPDATES = "allowed_updates"
         const val DROP_PENDING_UPDATES = "drop_pending_updates"
+        const val SECRET_TOKEN = "secret_token"
     }
 
     object SetChatAdministratorCustomTitle {

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiService.kt
@@ -57,6 +57,7 @@ internal interface ApiService {
         @Field(ApiConstants.SetWebhook.MAX_CONNECTIONS) maxConnections: Int? = null,
         @Field(ApiConstants.SetWebhook.ALLOWED_UPDATES) allowedUpdates: List<String>? = null,
         @Field(ApiConstants.SetWebhook.DROP_PENDING_UPDATES) dropPendingUpdates: Boolean? = null,
+        @Field(ApiConstants.SetWebhook.SECRET_TOKEN) secretToken: String? = null,
     ): Call<Response<Boolean>>
 
     @FormUrlEncoded
@@ -68,6 +69,7 @@ internal interface ApiService {
         @Field(ApiConstants.SetWebhook.MAX_CONNECTIONS) maxConnections: Int? = null,
         @Field(ApiConstants.SetWebhook.ALLOWED_UPDATES) allowedUpdates: List<String>? = null,
         @Field(ApiConstants.SetWebhook.DROP_PENDING_UPDATES) dropPendingUpdates: Boolean? = null,
+        @Field(ApiConstants.SetWebhook.SECRET_TOKEN) secretToken: String? = null,
     ): Call<Response<Boolean>>
 
     @FormUrlEncoded
@@ -79,6 +81,7 @@ internal interface ApiService {
         @Field(ApiConstants.SetWebhook.MAX_CONNECTIONS) maxConnections: Int? = null,
         @Field(ApiConstants.SetWebhook.ALLOWED_UPDATES) allowedUpdates: List<String>? = null,
         @Field(ApiConstants.SetWebhook.DROP_PENDING_UPDATES) dropPendingUpdates: Boolean? = null,
+        @Field(ApiConstants.SetWebhook.SECRET_TOKEN) secretToken: String? = null,
     ): Call<Response<Boolean>>
 
     @Multipart
@@ -90,6 +93,7 @@ internal interface ApiService {
         @Part maxConnections: MultipartBody.Part? = null,
         @Part allowedUpdates: MultipartBody.Part? = null,
         @Part dropPendingUpdates: MultipartBody.Part? = null,
+        @Part secretToken: MultipartBody.Part? = null,
     ): Call<Response<Boolean>>
 
     @GET("deleteWebhook")

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/webhook/WebhookConfig.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/webhook/WebhookConfig.kt
@@ -9,10 +9,11 @@ class WebhookConfigBuilder {
     var maxConnections: Int? = null
     var allowedUpdates: List<String>? = null
     var dropPendingUpdates: Boolean? = null
+    var secretToken: String? = null
 
     internal fun build(): WebhookConfig {
         val finalUrl = url ?: error("You must provide a url for the webhook")
-        return WebhookConfig(finalUrl, certificate, ipAddress, maxConnections, allowedUpdates, dropPendingUpdates)
+        return WebhookConfig(finalUrl, certificate, ipAddress, maxConnections, allowedUpdates, dropPendingUpdates, secretToken)
     }
 }
 
@@ -23,4 +24,5 @@ data class WebhookConfig(
     val maxConnections: Int? = null,
     val allowedUpdates: List<String>? = null,
     val dropPendingUpdates: Boolean? = null,
+    val secretToken: String? = null
 )

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/webhook/WebhookConfig.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/webhook/WebhookConfig.kt
@@ -24,5 +24,5 @@ data class WebhookConfig(
     val maxConnections: Int? = null,
     val allowedUpdates: List<String>? = null,
     val dropPendingUpdates: Boolean? = null,
-    val secretToken: String? = null
+    val secretToken: String? = null,
 )

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/BotIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/BotIT.kt
@@ -64,6 +64,7 @@ class BotIT {
             apiUrl = webServerUrl
             webhook {
                 url = ANY_WEBHOOK_URL
+                secretToken = ANY_SECRET_TOKEN
             }
         }
         givenSetWebhookSucceeds()
@@ -158,5 +159,6 @@ class BotIT {
     private companion object {
         const val ANY_BOT_TOKEN = "1342142:asdad"
         const val ANY_WEBHOOK_URL = "https://ruka.io"
+        const val ANY_SECRET_TOKEN = "secret-token"
     }
 }

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SetWebhookIT.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/network/apiclient/SetWebhookIT.kt
@@ -82,6 +82,15 @@ class SetWebhookIT : ApiClientIT() {
         thenSetWebhookRequestWithCertificateAsFileUrlAndWithIpAddressIsCorrect()
     }
 
+    @Test
+    internal fun `setWebhook with secret token`() {
+        givenAnyMockedResponse()
+
+        whenWebhookIsSetWithSecretToken()
+
+        thenSetWebhookRequestWithSecretTokenIsCorrect()
+    }
+
     private fun givenAnyMockedResponse() {
         val mockedResponse = MockResponse()
             .setResponseCode(200)
@@ -97,6 +106,10 @@ class SetWebhookIT : ApiClientIT() {
 
     private fun whenWebhookIsSetWithoutCertificate() {
         sut.setWebhook(url = ANY_WEBHOOK_URL).execute()
+    }
+
+    private fun whenWebhookIsSetWithSecretToken() {
+        sut.setWebhook(url = ANY_WEBHOOK_URL, secretToken = ANY_SECRET_TOKEN).execute()
     }
 
     private fun whenWebhookIsSetWithoutCertificateAndWithIpAddress() {
@@ -152,6 +165,12 @@ class SetWebhookIT : ApiClientIT() {
         val request = mockWebServer.takeRequest()
         val requestBody = request.body.readUtf8()
         assertEquals("url=https%3A%2F%2Fwebhook.telegram.io", requestBody)
+    }
+
+    private fun thenSetWebhookRequestWithSecretTokenIsCorrect() {
+        val request = mockWebServer.takeRequest()
+        val requestBody = request.body.readUtf8()
+        assertEquals("url=https%3A%2F%2Fwebhook.telegram.io&secret_token=secret-token", requestBody)
     }
 
     private fun thenSetWebhookRequestWithoutCertificateAndWithIpAddressIsCorrect() {
@@ -224,5 +243,6 @@ class SetWebhookIT : ApiClientIT() {
         const val ANY_FILE_ID = "rukaFileId1214"
         const val ANY_FILE_URL = "https://www.mycert.es/ruka"
         const val ANY_IP_ADDRESS = "214.88.209.113"
+        const val ANY_SECRET_TOKEN = "secret-token"
     }
 }


### PR DESCRIPTION
Leveraging `secret_token` property of the method [here](https://core.telegram.org/bots/api#setwebhook)