### PR TITLE
Update okhttp3 version to the latest && fix compile errors after that

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Java 8
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: temurin
           java-version: 8
 
       - name: Build with Gradle
@@ -34,7 +34,7 @@ jobs:
           TEST_RESULTS_PATH: telegram/build/reports/tests/test/index.html
       - name: Attach the report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Tests report
           path: ${{ steps.xunit-viewer.outputs.report-dir }}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,8 +6,8 @@ kotlinx-binary-compatibility-validator = "0.13.2"
 kotlin-coroutines = "1.6.2"
 ktor = "1.6.3"
 mockk = "1.10.2"
-okhttp3-logging-interceptor = "3.8.0"
-okhttp3-mockwebserver = "4.2.1"
+okhttp3-logging-interceptor = "4.12.0"
+okhttp3-mockwebserver = "4.12.0"
 retrofit = "2.9.0"
 
 [libraries]

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -48,7 +48,7 @@ import com.github.kotlintelegrambot.types.TelegramBotResult
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import okhttp3.Interceptor
-import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody
 import okhttp3.ResponseBody
@@ -60,8 +60,8 @@ import java.net.Proxy
 import java.util.concurrent.TimeUnit
 import java.io.File as SystemFile
 
-internal val PLAIN_TEXT_MIME = MediaType.parse("text/plain")
-internal val APPLICATION_JSON_MIME = MediaType.parse("application/json")
+internal val PLAIN_TEXT_MIME = "text/plain".toMediaTypeOrNull()
+internal val APPLICATION_JSON_MIME = "application/json".toMediaTypeOrNull()
 
 private fun convertString(text: String) = RequestBody.create(PLAIN_TEXT_MIME, text)
 private fun convertJson(text: String) = RequestBody.create(APPLICATION_JSON_MIME, text)

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/multipart/MultipartExtensions.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/multipart/MultipartExtensions.kt
@@ -1,6 +1,6 @@
 package com.github.kotlintelegrambot.network.multipart
 
-import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import java.io.File
@@ -10,7 +10,7 @@ internal fun File.toMultipartBodyPart(
     partName: String = name,
     mediaType: String? = null,
 ): MultipartBody.Part {
-    val mimeType = (mediaType ?: Files.probeContentType(toPath()))?.let { MediaType.parse(it) }
+    val mimeType = (mediaType ?: Files.probeContentType(toPath()))?.toMediaTypeOrNull()
     val requestBody = RequestBody.create(mimeType, this)
 
     return MultipartBody.Part.createFormData(partName, name, requestBody)
@@ -28,7 +28,7 @@ internal fun ByteArray.toMultipartBodyPart(
     filename: String? = partName,
     mediaType: String? = null,
 ): MultipartBody.Part {
-    val mimeType = mediaType?.let { MediaType.parse(it) }
+    val mimeType = mediaType?.toMediaTypeOrNull()
     val requestBody = RequestBody.create(mimeType, this)
 
     return MultipartBody.Part.createFormData(partName, filename ?: partName, requestBody)


### PR DESCRIPTION
Update okhttp3 version to the latest && fix compile errors after that.

Close issue #271.

Compile errors were (just for the history):
```
 Task :telegram:compileKotlin FAILED
e: kotlin-telegram-bot/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt:63:42 Using 'parse(String): MediaType?' is an error. moved to extension function
e: kotlin-telegram-bot/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt:64:48 Using 'parse(String): MediaType?' is an error. moved to extension function
e: kotlin-telegram-bot/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/multipart/MultipartExtensions.kt:13:85 Using 'parse(String): MediaType?' is an error. moved to extension function
e: kotlin-telegram-bot/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/multipart/MultipartExtensions.kt:31:47 Using 'parse(String): MediaType?' is an error. moved to extension function

FAILURE: Build failed with an exception.
```
