### PR TITLE
Add support for sending files via InputStream

### DIFF
--- a/telegram/api/telegram.api
+++ b/telegram/api/telegram.api
@@ -1552,6 +1552,24 @@ public final class com/github/kotlintelegrambot/entities/TelegramFile$ByFileId :
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/github/kotlintelegrambot/entities/TelegramFile$ByInputStream : com/github/kotlintelegrambot/entities/TelegramFile {
+	public fun <init> (Ljava/io/InputStream;Ljava/lang/String;Lokhttp3/MediaType;J)V
+	public synthetic fun <init> (Ljava/io/InputStream;Ljava/lang/String;Lokhttp3/MediaType;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/io/InputStream;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lokhttp3/MediaType;
+	public final fun component4 ()J
+	public final fun copy (Ljava/io/InputStream;Ljava/lang/String;Lokhttp3/MediaType;J)Lcom/github/kotlintelegrambot/entities/TelegramFile$ByInputStream;
+	public static synthetic fun copy$default (Lcom/github/kotlintelegrambot/entities/TelegramFile$ByInputStream;Ljava/io/InputStream;Ljava/lang/String;Lokhttp3/MediaType;JILjava/lang/Object;)Lcom/github/kotlintelegrambot/entities/TelegramFile$ByInputStream;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContentLength ()J
+	public final fun getContentType ()Lokhttp3/MediaType;
+	public final fun getFilename ()Ljava/lang/String;
+	public final fun getStream ()Ljava/io/InputStream;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/github/kotlintelegrambot/entities/TelegramFile$ByUrl : com/github/kotlintelegrambot/entities/TelegramFile {
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -3629,10 +3647,13 @@ public final class com/github/kotlintelegrambot/network/ResponseError {
 }
 
 public final class com/github/kotlintelegrambot/network/UtilsKt {
+	public static final fun asMultipartBodyPart (Lcom/github/kotlintelegrambot/entities/TelegramFile$ByInputStream;Ljava/lang/String;)Lokhttp3/MultipartBody$Part;
 	public static final fun bimap (Lkotlin/Pair;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun call (Lretrofit2/Call;)Lkotlin/Pair;
 	public static final fun fold (Lkotlin/Pair;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun fold$default (Lkotlin/Pair;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun toRequestBody (Ljava/io/InputStream;Lokhttp3/MediaType;J)Lokhttp3/RequestBody;
+	public static synthetic fun toRequestBody$default (Ljava/io/InputStream;Lokhttp3/MediaType;JILjava/lang/Object;)Lokhttp3/RequestBody;
 }
 
 public abstract class com/github/kotlintelegrambot/types/ConsumableObject {

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/TelegramFile.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/entities/TelegramFile.kt
@@ -1,6 +1,8 @@
 package com.github.kotlintelegrambot.entities
 
+import okhttp3.MediaType
 import java.io.File
+import java.io.InputStream
 
 sealed class TelegramFile {
     data class ByFileId(val fileId: String) : TelegramFile()
@@ -23,4 +25,11 @@ sealed class TelegramFile {
             return result
         }
     }
+
+    data class ByInputStream(
+        val stream: InputStream,
+        val filename: String? = null,
+        val contentType: MediaType? = null,
+        val contentLength: Long = -1,
+    ) : TelegramFile()
 }

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/Utils.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/Utils.kt
@@ -1,8 +1,15 @@
 package com.github.kotlintelegrambot.network
 
+import com.github.kotlintelegrambot.entities.TelegramFile
+import okhttp3.MediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
 import okhttp3.ResponseBody
+import okio.BufferedSink
+import okio.source
 import retrofit2.Call
 import retrofit2.Response
+import java.io.InputStream
 
 fun <T> Call<T>.call(): Pair<Response<T?>?, Exception?> = try {
     Pair(execute(), null)
@@ -27,3 +34,20 @@ fun <T, R> Pair<Response<T?>?, Exception?>.bimap(mapResponse: (T?) -> R, mapErro
     } else {
         mapError(ResponseError(first?.errorBody(), second))
     }
+
+fun InputStream.toRequestBody(
+    contentType: MediaType?,
+    contentLength: Long = -1,
+): RequestBody = object : RequestBody() {
+    override fun contentType(): MediaType? = contentType
+
+    override fun contentLength(): Long = contentLength
+
+    override fun writeTo(sink: BufferedSink) {
+        this@toRequestBody.use {
+            sink.writeAll(it.source())
+        }
+    }
+}
+
+fun TelegramFile.ByInputStream.asMultipartBodyPart(partName: String) = MultipartBody.Part.createFormData(partName, filename ?: partName, stream.toRequestBody(contentType, contentLength))

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/serialization/adapter/TelegramFileAdapter.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/serialization/adapter/TelegramFileAdapter.kt
@@ -16,5 +16,6 @@ internal class TelegramFileAdapter : JsonSerializer<TelegramFile> {
         is ByUrl -> context.serialize(src.url, String::class.java)
         is ByFile -> context.serialize("attach://${src.file.name}")
         is ByByteArray -> context.serialize("attach://${src.filename!!}")
+        is TelegramFile.ByInputStream -> context.serialize("attach://${src.filename!!}")
     }
 }


### PR DESCRIPTION
This PR adds TelegramFile.ByInputStream, which allows to send files without storing the whole blob on disk or in RAM. Fields of this data class are created independently of [almost same looking Media data class in trixnity](https://gitlab.com/trixnity/trixnity/-/blob/f42affe255ce526b6d3e6f359afbfbdd5997484a/trixnity-clientserverapi/trixnity-clientserverapi-model/src/commonMain/kotlin/net/folivo/trixnity/clientserverapi/model/media/Media.kt) (which has the same purpose), confirming my approach is optimal.  
<sub>I literally realized those two are pretty similar only when started to type this text. Only contentDisposition and filename differ, however contentDisposition is simply a wrapper for filename with metadata</sub>

This PR also adds a sample which closely represents the case we have stumbled upon: copying images from remote server (which requires authorization - not included in the sample) to telegram. There's no point in storing file locally and so this is the clean approach. The sample is clearly not intended as an example usage for library users as it is confusing them, so I expect it to be rejected. However, it is included to a) test it b) show usage (but remember that in our case remote server requires authorization and so TelegramFile.ByUrl will fail).

The changes are fully tested using sample (but only on `sendPhoto`). Filename, contentLength and contentType observed not to be required. There are some concerns which I would like to show using comments on individual lines.