### PR TITLE
added handler for text message edit event

### DIFF
--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/HandlersDsl.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/HandlersDsl.kt
@@ -46,6 +46,7 @@ import com.github.kotlintelegrambot.dispatcher.handlers.NewChatJoinRequestHandle
 import com.github.kotlintelegrambot.dispatcher.handlers.NewChatMembersHandler
 import com.github.kotlintelegrambot.dispatcher.handlers.PollAnswerHandler
 import com.github.kotlintelegrambot.dispatcher.handlers.PreCheckoutQueryHandler
+import com.github.kotlintelegrambot.dispatcher.handlers.TextEditHandler
 import com.github.kotlintelegrambot.dispatcher.handlers.TextHandler
 import com.github.kotlintelegrambot.dispatcher.handlers.media.AnimationHandler
 import com.github.kotlintelegrambot.dispatcher.handlers.media.AudioHandler
@@ -74,6 +75,10 @@ fun Dispatcher.command(command: String, handleCommand: HandleCommand) {
 
 fun Dispatcher.text(text: String? = null, handleText: HandleText) {
     addHandler(TextHandler(text, handleText))
+}
+
+fun Dispatcher.textEdit(text: String? = null, handleText: HandleText) {
+    addHandler(TextEditHandler(text, handleText))
 }
 
 fun Dispatcher.callbackQuery(data: String? = null, handleCallbackQuery: HandleCallbackQuery) {

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/TextEditHandler.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/TextEditHandler.kt
@@ -1,0 +1,34 @@
+package com.github.kotlintelegrambot.dispatcher.handlers
+
+import com.github.kotlintelegrambot.Bot
+import com.github.kotlintelegrambot.entities.Message
+import com.github.kotlintelegrambot.entities.Update
+import com.github.kotlintelegrambot.dispatcher.handlers.TextHandler
+
+
+class TextEditHandler(
+    private val text: String? = null,
+    private val handleText: HandleText,
+) : Handler {
+
+    override fun checkUpdate(update: Update): Boolean {
+        if (update.editedMessage?.text != null && text == null) {
+            return true
+        } else if (text != null) {
+            return update.editedMessage?.text != null && update.editedMessage.text.contains(text, ignoreCase = true)
+        }
+        return false
+    }
+
+    override suspend fun handleUpdate(bot: Bot, update: Update) {
+        checkNotNull(update.editedMessage)
+        checkNotNull(update.editedMessage.text)
+        val textHandlerEnv = TextHandlerEnvironment(
+            bot,
+            update,
+            update.editedMessage,
+            update.editedMessage.text,
+        )
+        handleText(textHandlerEnv)
+    }
+}

--- a/telegram/src/test/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/TextEditHandlerTest.kt
+++ b/telegram/src/test/kotlin/com/github/kotlintelegrambot/dispatcher/handlers/TextEditHandlerTest.kt
@@ -1,0 +1,100 @@
+package com.github.kotlintelegrambot.dispatcher.handlers
+
+import anyMessage
+import anyUpdate
+import com.github.kotlintelegrambot.Bot
+import io.mockk.coVerify
+import io.mockk.mockk
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class TextEditHandlerTest {
+
+    private val handleTextMock = mockk<HandleText>(relaxed = true)
+
+    @Test
+    fun `checkUpdate returns false when update has no editedMessage`() {
+        val anyUpdateWithNoMessage = anyUpdate(editedMessage = null)
+        val sut = TextEditHandler(text = "", handleText = handleTextMock)
+
+        val checkUpdateResult = sut.checkUpdate(anyUpdateWithNoMessage)
+
+        assertFalse(checkUpdateResult)
+    }
+
+    @Test
+    fun `checkUpdate returns false when editedMessage has no text`() {
+        val anyMessageWithNoText = anyUpdate(editedMessage = anyMessage(text = null))
+        val sut = TextEditHandler(text = "", handleText = handleTextMock)
+
+        val checkUpdateResult = sut.checkUpdate(anyMessageWithNoText)
+
+        assertFalse(checkUpdateResult)
+    }
+
+    @Test
+    fun `checkUpdate returns true when editedMessage has text and there is no text to match`() {
+        val anyMessageWithText = anyUpdate(editedMessage = anyMessage(text = ANY_TEXT))
+        val sut = TextEditHandler(text = null, handleText = handleTextMock)
+
+        val checkUpdateResult = sut.checkUpdate(anyMessageWithText)
+
+        assertTrue(checkUpdateResult)
+    }
+
+    @Test
+    fun `checkUpdate returns false when editedMessage has text and it doesn't match the text to match`() {
+        val anyMessageWithText = anyUpdate(editedMessage = anyMessage(text = ANY_TEXT))
+        val sut = TextEditHandler(text = ANY_OTHER_TEXT, handleText = handleTextMock)
+
+        val checkUpdateResult = sut.checkUpdate(anyMessageWithText)
+
+        assertFalse(checkUpdateResult)
+    }
+
+    @Test
+    fun `checkUpdate returns true when editedMessage has text and it's equal to the text to match`() {
+        val anyMessageWithText = anyUpdate(editedMessage = anyMessage(text = ANY_TEXT))
+        val sut = TextEditHandler(text = ANY_TEXT, handleText = handleTextMock)
+
+        val checkUpdateResult = sut.checkUpdate(anyMessageWithText)
+
+        assertTrue(checkUpdateResult)
+    }
+
+    @Test
+    fun `checkUpdate returns true when editedMessage has text and it contains the text to match`() {
+        val anyMessageWithText = anyUpdate(editedMessage = anyMessage(text = ANY_TEXT))
+        val sut = TextEditHandler(text = ANY_TEXT_CONTAINED_IN_ANY_TEXT, handleText = handleTextMock)
+
+        val checkUpdateResult = sut.checkUpdate(anyMessageWithText)
+
+        assertTrue(checkUpdateResult)
+    }
+
+    @Test
+    fun `text is properly dispatched to the handler function`() = runTest {
+        val botMock = mockk<Bot>()
+        val anyMessageWithText = anyMessage(text = ANY_TEXT)
+        val anyUpdate = anyUpdate(editedMessage = anyMessageWithText)
+        val sut = TextEditHandler(text = ANY_TEXT, handleText = handleTextMock)
+
+        sut.handleUpdate(botMock, anyUpdate)
+
+        val expectedTextHandlerEnvironment = TextHandlerEnvironment(
+            botMock,
+            anyUpdate,
+            anyMessageWithText,
+            ANY_TEXT,
+        )
+        coVerify { handleTextMock.invoke(expectedTextHandlerEnvironment) }
+    }
+
+    private companion object {
+        const val ANY_TEXT = "Valar Morghulis"
+        const val ANY_OTHER_TEXT = "Valar Dohaeris"
+        const val ANY_TEXT_CONTAINED_IN_ANY_TEXT = "Valar"
+    }
+}


### PR DESCRIPTION
dispatch.text does not process existing message edit event. This handler is helpfull against spamers, that create good message and then edit it to bad one. 