### PR TITLE
Add proxy authentication for HTTP proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The current line (`10.x`) is up to date with Bot API 10.0 and includes the break
 - [Webhooks](docs/webhooks.md) — `webhook { }` DSL, `secretToken`, manual `processUpdate`.
 - [Error handling](docs/errorHandling.md) — `TelegramBotResult` and `telegramError { }`.
 - [Logging](docs/logging.md).
+- [Proxy](docs/proxy.md) — HTTP proxy and username/password authentication.
 - [File uploads](docs/fileUploads.md) — `TelegramFile.ByFile` / `ByByteArray` / `ByInputStream` / `ByUrl` / `ByFileId`.
 
 **Chat and messages**

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -1,0 +1,46 @@
+# Proxy configuration
+
+The library can route Telegram API traffic through a proxy with `Bot.Builder.proxy`.
+
+If you need extra OkHttp setup, use `Bot.Builder.okHttpClientConfigurator`. The configurator is applied to the internal `OkHttpClient.Builder`, so you can attach proxy authentication, custom TLS settings, DNS, or any other supported OkHttp option.
+
+## HTTP proxy with authenticator
+
+```kotlin
+import okhttp3.Authenticator
+import okhttp3.Credentials
+import okhttp3.Response
+import okhttp3.Route
+import java.net.InetSocketAddress
+import java.net.Proxy
+
+fun main() {
+    val proxyAuthenticator = Authenticator { _: Route?, response: Response ->
+        response.request.newBuilder()
+            .header("Proxy-Authorization", Credentials.basic("proxy-user", "proxy-password"))
+            .build()
+    }
+
+    val bot = bot {
+        token = "YOUR_API_KEY"
+        proxy = Proxy(Proxy.Type.HTTP, InetSocketAddress("proxy.corp.example", 8080))
+        okHttpClientConfigurator = {
+            proxyAuthenticator(proxyAuthenticator)
+        }
+        dispatch {
+            // ...
+        }
+    }
+    bot.startPolling()
+}
+```
+
+## Notes
+
+- `proxy` still controls the transport route.
+- `okHttpClientConfigurator` only affects the OkHttp client created for that bot instance.
+- The configurator can be used for more than proxy auth, so the public API stays generic.
+
+## Related
+
+- [Logging](logging.md) — optional HTTP request/response logs when debugging proxy issues.

--- a/telegram/api/telegram.api
+++ b/telegram/api/telegram.api
@@ -253,6 +253,7 @@ public final class com/github/kotlintelegrambot/Bot$Builder {
 	public final fun getCoroutineDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public final fun getHttpClientInterceptors ()Ljava/util/List;
 	public final fun getLogLevel ()Lcom/github/kotlintelegrambot/logging/LogLevel;
+	public final fun getOkHttpClientConfigurator ()Lkotlin/jvm/functions/Function1;
 	public final fun getProxy ()Ljava/net/Proxy;
 	public final fun getTimeout ()I
 	public final fun getToken ()Ljava/lang/String;
@@ -261,6 +262,7 @@ public final class com/github/kotlintelegrambot/Bot$Builder {
 	public final fun setCoroutineDispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)V
 	public final fun setHttpClientInterceptors (Ljava/util/List;)V
 	public final fun setLogLevel (Lcom/github/kotlintelegrambot/logging/LogLevel;)V
+	public final fun setOkHttpClientConfigurator (Lkotlin/jvm/functions/Function1;)V
 	public final fun setProxy (Ljava/net/Proxy;)V
 	public final fun setTimeout (I)V
 	public final fun setToken (Ljava/lang/String;)V

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/Bot.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.channels.Channel
 import okhttp3.Interceptor
+import okhttp3.OkHttpClient
 import java.net.Proxy
 import java.util.concurrent.Executors
 import java.io.File as SystemFile
@@ -84,12 +85,23 @@ class Bot private constructor(
         var proxy: Proxy = Proxy.NO_PROXY
         var coroutineDispatcher: CoroutineDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
         var httpClientInterceptors: List<Interceptor> = emptyList()
+        var okHttpClientConfigurator: OkHttpClient.Builder.() -> Unit = { }
         internal var dispatcherConfiguration: Dispatcher.() -> Unit = { }
 
         fun build(): Bot {
             val updatesQueue = Channel<DispatchableObject>()
             val looper = CoroutineLooper(Dispatchers.IO)
-            val apiClient = ApiClient(token, apiUrl, timeout, logLevel, proxy, gson, httpClientInterceptors = httpClientInterceptors)
+            val apiClient =
+                ApiClient(
+                    token,
+                    apiUrl,
+                    timeout,
+                    logLevel,
+                    proxy,
+                    gson,
+                    httpClientInterceptors = httpClientInterceptors,
+                    okHttpClientConfigurator = okHttpClientConfigurator,
+                )
             val updater = Updater(looper, updatesQueue, apiClient, timeout)
             val dispatcher =
                 Dispatcher(

--- a/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
+++ b/telegram/src/main/kotlin/com/github/kotlintelegrambot/network/ApiClient.kt
@@ -81,6 +81,7 @@ internal class ApiClient(
     private val apiRequestSender: ApiRequestSender = ApiRequestSender(),
     private val apiResponseMapper: ApiResponseMapper = ApiResponseMapper(),
     private val httpClientInterceptors: List<Interceptor> = emptyList(),
+    private val okHttpClientConfigurator: OkHttpClient.Builder.() -> Unit = { },
 ) {
     private val service: ApiService
 
@@ -98,6 +99,7 @@ internal class ApiClient(
                 .also { builder -> httpClientInterceptors.forEach { builder.addInterceptor(it) } }
                 .retryOnConnectionFailure(true)
                 .proxy(proxy)
+                .apply(okHttpClientConfigurator)
                 .build()
 
         val retrofit =


### PR DESCRIPTION
Added okHttpClientConfigurator on Bot.Builder, wired into ApiClient via apply after proxy. Added docs/proxy.md (HTTP proxy auth example) and README link. Updated telegram.api. Unchanged: proxy routing, httpClientInterceptors, SOCKS without auth.

Before this commit the library only set the proxy route; HTTP proxy credentials had to be configured outside the public API. The configurator exposes OkHttp setup per bot without hard-coding username/password fields in the library.